### PR TITLE
cmdline: ignore during bootstrap the .sh file

### DIFF
--- a/lib/autoproj/cmdline.rb
+++ b/lib/autoproj/cmdline.rb
@@ -1547,7 +1547,7 @@ where 'mode' is one of:
             end
 
             require 'set'
-            curdir_entries = Dir.entries('.').to_set - [".", "..", "autoproj_bootstrap", ".gems", ENV_FILENAME].to_set
+            curdir_entries = Dir.entries('.').to_set - [".", "..", "autoproj_bootstrap", ".gems", "bootstrap.sh", ENV_FILENAME].to_set
             if !curdir_entries.empty? && ENV['AUTOPROJ_BOOTSTRAP_IGNORE_NONEMPTY_DIR'] != '1'
                 while true
                     print "The current directory is not empty, continue bootstrapping anyway ? [yes] "


### PR DESCRIPTION
This meets the documentation at:
http://www.rock-robotics.org/stable/documentation/installation.html
and the normal usecase.
