### PR TITLE
Tune github access

### DIFF
--- a/lib/autoproj/gitorious.rb
+++ b/lib/autoproj/gitorious.rb
@@ -79,5 +79,5 @@ module Autoproj
 end
 
 Autoproj.gitorious_server_configuration('GITORIOUS', 'gitorious.org')
-Autoproj.gitorious_server_configuration('GITHUB', 'github.com', :http_url => 'https://github.com')
+Autoproj.gitorious_server_configuration('GITHUB', 'github.com', :http_url => 'https://github.com', :default => 'http,ssh')
 


### PR DESCRIPTION
It seems that the https access is the preferred access mode on github (and I wonder if it is not faster). However, pushing via https is a pain (requires username/password), so we need to support pulling with http and pushing with ssh.
