### PR TITLE
osdep: warn about osdep overriding each other only for this specific OS

### DIFF
--- a/lib/autoproj/osdeps.rb
+++ b/lib/autoproj/osdeps.rb
@@ -998,7 +998,20 @@ fi
                     root_dir ||= "#{Autoproj.root_dir}/"
                     old = source_of(h).gsub(root_dir, '')
                     new = info.source_of(h).gsub(root_dir, '')
-                    Autoproj.warn("osdeps definition for #{h}, previously defined in #{old} overridden by #{new}")
+
+                    # Warn if the new osdep definition resolves to a different
+                    # set of packages than the old one
+                    old_resolved = resolve_package(h).inject(Hash.new) do |osdep_h, (handler, status, list)|
+                        osdep_h[handler.name] = [status, list]
+                        h
+                    end
+                    new_resolved = info.resolve_package(h).inject(Hash.new) do |osdep_h, (handler, status, list)|
+                        osdep_h[handler.name] = [status, list]
+                        h
+                    end
+                    if old_resolved != new_resolved
+                        Autoproj.warn("osdeps definition for #{h}, previously defined in #{old} overridden by #{new}")
+                    end
                 end
                 v2
             end


### PR DESCRIPTION
This avoids having a warning if a package set has for instance added
the relevant osdeps for new operating systems that are not supported
by the original package set.
