### PR TITLE
Improve test support

### DIFF
--- a/bin/autoproj-test
+++ b/bin/autoproj-test
@@ -3,9 +3,38 @@
 require 'autoproj'
 require 'autoproj/cmdline'
 
-user_selection = Autoproj.silent do
-    Autoproj::CmdLine.initialize_root_directory
-    Autoproj::CmdLine.initialize_and_load(ARGV)
+modified_config = false
+list_config = false
+Autoproj.load_config
+options = OptionParser.new do |opt|
+    opt.on '--enable[=PACKAGE,PACKAGE]', Array, 'enable tests for all packages or for specific packages (does not run the tests)' do |packages|
+        if !packages
+            Autoproj.config.utility_enable_all('test')
+        else
+            Autoproj.config.utility_enable_for('test', *packages)
+        end
+        modified_config = true
+    end
+    opt.on '--disable[=PACKAGE,PACKAGE]', Array, 'disable tests for all packages or for specific packages (does not run the tests)' do |packages|
+        if !packages
+            Autoproj.config.utility_disable_all('test')
+        else
+            Autoproj.config.utility_disable_for('test', *packages)
+        end
+        modified_config = true
+    end
+    opt.on '--list', 'list the test availability and enabled/disabled state information' do
+        list_config = true
+    end
+end
+
+user_selection = options.parse(ARGV)
+
+if modified_config
+    Autoproj.save_config
+    if !list_config
+        exit 0
+    end
 end
 
 user_selection = user_selection.map do |arg|
@@ -13,6 +42,26 @@ user_selection = user_selection.map do |arg|
         File.expand_path(arg)
     else arg
     end
+end
+
+Autoproj.silent do
+    Autoproj::CmdLine.initialize_root_directory
+    Autoproj::CmdLine.initialize_and_load([])
+end
+
+if list_config
+    lines = Array.new
+    Autoproj.manifest.each_autobuild_package do |pkg|
+        lines << [pkg.name, pkg.test_utility.enabled?, pkg.test_utility.available?]
+    end
+    lines = lines.sort_by { |name, _| name }
+    w     = lines.map { |name, _| name.length }.max
+    format = "%-#{w}s %-7s %-9s"
+    puts format % ["Package Name", "Enabled", "Available"]
+    lines.each do |name, enabled, available|
+        puts(format % [name, (!!enabled).to_s, (!!available).to_s])
+    end
+    exit 0
 end
 
 Autobuild.pass_test_errors = true

--- a/lib/autoproj/autobuild.rb
+++ b/lib/autoproj/autobuild.rb
@@ -405,8 +405,8 @@ end
 def cmake_package(options, &block)
     package_common(:cmake, options) do |pkg|
         pkg.depends_on 'cmake'
-        yield(pkg) if block_given?
         common_make_based_package_setup(pkg)
+        yield(pkg) if block_given?
     end
 end
 
@@ -422,8 +422,8 @@ end
 def autotools_package(options, &block)
     package_common(:autotools, options) do |pkg|
         pkg.depends_on 'autotools'
-        yield(pkg) if block_given?
         common_make_based_package_setup(pkg)
+        yield(pkg) if block_given?
     end
 end
 
@@ -447,8 +447,6 @@ end
 # information.
 def ruby_package(options)
     package_common(:ruby, options) do |pkg|
-        yield(pkg) if block_given?
-
         # Documentation code. Ignore if the user provided its own documentation
         # task, or disabled the documentation generation altogether by setting
         # rake_doc_task to nil
@@ -467,6 +465,8 @@ def ruby_package(options)
                 pkg.with_tests
             end
         end
+
+        yield(pkg) if block_given?
     end
 end
 

--- a/lib/autoproj/autobuild.rb
+++ b/lib/autoproj/autobuild.rb
@@ -483,6 +483,7 @@ end
 # information.
 def orogen_package(options, &block)
     package_common(:orogen, options) do |pkg|
+        common_make_based_package_setup(pkg)
         yield(pkg) if block_given?
     end
 end

--- a/lib/autoproj/cmdline.rb
+++ b/lib/autoproj/cmdline.rb
@@ -254,6 +254,13 @@ module Autoproj
                 end
             end
 
+            manifest.each_autobuild_package do |pkg|
+                Autobuild.each_utility do |uname, _|
+                    pkg.utility(uname).enabled =
+                        config.utility_enabled_for?(uname, pkg.name)
+                end
+            end
+
             # We finished loading the configuration files. Not all configuration
             # is done (since we need to process the package setup blocks), but
             # save the current state of the configuration anyway.
@@ -314,10 +321,6 @@ module Autoproj
             # Now call the blocks that the user defined in the autobuild files. We do it
             # now so that the various package directories are properly setup
             manifest.packages.each_value do |pkg|
-                Autobuild.utilities.keys.each do |utility|
-                    pkg.autobuild.utility(utility).enabled = Autoproj.config.utility_enabled_for?(utility, pkg.name)
-                end
-                
                 pkg.user_blocks.each do |blk|
                     blk[pkg.autobuild]
                 end

--- a/lib/autoproj/cmdline.rb
+++ b/lib/autoproj/cmdline.rb
@@ -314,6 +314,10 @@ module Autoproj
             # Now call the blocks that the user defined in the autobuild files. We do it
             # now so that the various package directories are properly setup
             manifest.packages.each_value do |pkg|
+                Autobuild.utilities.keys.each do |utility|
+                    pkg.autobuild.utility(utility).enabled = Autoproj.config.utility_enabled_for?(utility, pkg.name)
+                end
+                
                 pkg.user_blocks.each do |blk|
                     blk[pkg.autobuild]
                 end

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -210,10 +210,21 @@ module Autoproj
             end
         end
 
+        # Returns true if packages and prefixes should be auto-generated, based
+        # on the SHA of the package names. This is meant to be used for build
+        # services that want to check that dependencies are properly set
+        #
+        # The default is false (disabled)
+        #
+        # @return [Boolean]
         def randomize_layout?
             get('randomize_layout', false)
         end
 
+        # Sets whether the layout should be randomized
+        #
+        # @return [Boolean]
+        # @see randomize_layout?
         def randomize_layout=(value)
             set('randomize_layout', value, true)
         end

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -217,6 +217,90 @@ module Autoproj
         def randomize_layout=(value)
             set('randomize_layout', value, true)
         end
+
+        DEFAULT_UTILITY_SETUP = Hash[
+            'doc' => true,
+            'test' => false]
+
+        # The configuration key that should be used to store the utility
+        # enable/disable information 
+        #
+        # @param [String] the utility name
+        # @return [String] the config key
+        def utility_key(utility)
+            "autoproj_#{utility}_utility"
+        end
+
+        # Returns whether a given utility is enabled for the package
+        #
+        # If there is no specific configuration for the package, uses the global
+        # default set with utility_enable_all or utility_disable_all. If none of
+        # these methods has been called, uses the default in
+        # {DEFAULT_UTILITY_SETUP}
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @param [String] package the package name
+        # @return [Boolean] true if the utility should be enabled for the
+        #   requested package and false otherwise
+        def utility_enabled_for?(utility, package)
+            utility_config = get(utility_key(utility), Hash.new)
+            if utility_config.has_key?(package)
+                utility_config[package]
+            else get("#{utility_key(utility)}_default", DEFAULT_UTILITY_SETUP[utility])
+            end
+        end
+
+        # Enables a utility for all packages
+        #
+        # This both sets the default value for all packages and resets all
+        # package-specific values set with {utility_enable_for} and
+        # {utility_disable_for}
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @return [void]
+        def utility_enable_all(utility)
+            reset(utility_key(utility))
+            set("#{utility_key(utility)}_default", true)
+        end
+
+        # Enables a utility for a specific package
+        #
+        # Note that if the default for this utility is to be enabled, this is
+        # essentially a no-op.
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @param [String] package the package name
+        # @return [void]
+        def utility_enable_for(utility, package)
+            utility_config = get(utility_key(utility), Hash.new)
+            set(utility_key(utility), utility_config.merge(package => true))
+        end
+
+        # Disables a utility for all packages
+        #
+        # This both sets the default value for all packages and resets all
+        # package-specific values set with {utility_enable_for} and
+        # {utility_disable_for}
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @return [void]
+        def utility_disable_all(utility)
+            reset(utility_key(utility))
+            set("#{utility_key(utility)}_default", false)
+        end
+
+        # Disables a utility for a specific package
+        #
+        # Note that if the default for this utility is to be disabled, this is
+        # essentially a no-op.
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @param [String] package the package name
+        # @return [void]
+        def utility_disable_for(utility, package)
+            utility_config = get(utility_key(utility), Hash.new)
+            set(utility_key(utility), utility_config.merge(package => false))
+        end
     end
 end
 

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -877,7 +877,7 @@ module Autoproj
             pkg.autobuild.description = manifest
             package_manifests[package.name] = manifest
 
-            manifest.each_dependency do |name, is_optional|
+            manifest.each_dependency(pkg.modes) do |name, is_optional|
                 begin
                     if is_optional
                         package.optional_dependency name

--- a/lib/autoproj/package_definition.rb
+++ b/lib/autoproj/package_definition.rb
@@ -32,6 +32,19 @@ module Autoproj
             @autobuild, @package_set, @file =
                 autobuild, package_set, file
             @user_blocks = []
+            @modes = ['import', 'build']
+        end
+
+        # The modes in which this package will be used
+        #
+        # Mainly used during dependency resolution to disable unneeded
+        # dependencies
+        #
+        # @return [Array<String>]
+        def modes
+            @modes + autobuild.utilities.values.
+                find_all { |u| u.enabled? }.
+                map(&:name)
         end
 
         # The package name


### PR DESCRIPTION
This depends on rock-core/autobuild#15

This pull request adds final touches to testing using autoproj.

1. it adds fine-grained control over which packages should have test enabled, with
```
autoproj test --enable[=PKG,PKG,PKG]
autoproj test --disable[=PKG,PKG,PKG]
```
(both will enable or disable tests for all packages if called without arguments). In addition,
```
  autoproj test --list
```
will show which packages have tests available and which have tests enabled.

2. it adds the ability to restrict some dependencies to packages for which tests are enabled, and also gives access to whether tests are enabled in the autobuild file. The former is to avoid installing a lot of packages that most user won't ever need, and the latter is to disable compiling tests when unneeded in packages where they are expensive.