### PR TITLE
fix: added missing splat operator to cacheinfo parameters

### DIFF
--- a/lib/autoproj/ops/snapshot.rb
+++ b/lib/autoproj/ops/snapshot.rb
@@ -240,7 +240,7 @@ module Autoproj
                 # And add the new file
                 importer.run_git_bare(
                     pkg, 'update-index',
-                    '--add', '--cacheinfo', cacheinfo)
+                    '--add', '--cacheinfo', *cacheinfo)
                 tree_id = importer.run_git_bare(pkg, 'write-tree').first
             ensure
                 ENV.delete('GIT_INDEX_FILE')


### PR DESCRIPTION
in case ruby version is less than 2.1.0, the cachinfo parameters have to
presented as individual arguments. Passing the array directly resulted
in a bad syntax for the git command line.