### PR TITLE
os-detection: use lsb_release also for debians

### DIFF
--- a/lib/autoproj/osdeps.rb
+++ b/lib/autoproj/osdeps.rb
@@ -1276,11 +1276,24 @@ fi
             Autobuild.progress :operating_system_autodetection, "autodetecting the operating system"
             names, versions = os_from_os_release
 
-            # Don't use the os-release information on Debian, since they
-            # refuse to put enough information to detect 'unstable'
-            # reliably. So, we use the heuristic method for it
-            if !names || names[0] == 'debian'
+            if !names
                 names, versions = guess_operating_system
+            end
+
+            # on Debian, they refuse to put enough information to detect
+            # 'unstable' reliably. So, we use the heuristic method for it
+            if names[0] = "debian"
+                # check if we actually got a debian with the "unstable" (sid)
+                # flavour. it seems that "/etc/debian_version" does not contain
+                # "sid" (but "8.0" for example) during the feature freeze
+                # phase...
+                if File.exists?('/etc/debian_version')
+                    debian_versions = [File.read('/etc/debian_version').strip]
+                    if debian_versions.first =~ /sid/
+                        versions = ["unstable", "sid"]
+                    end
+                end
+                # otherwise "versions" contains the result it previously had
             end
             return if !names
 

--- a/lib/autoproj/osdeps.rb
+++ b/lib/autoproj/osdeps.rb
@@ -1322,8 +1322,7 @@ fi
                 return
             end
 
-            distributor = `lsb_release -i -s`
-            distributor = distributor.strip.downcase
+            distributor = [`lsb_release -i -s`.strip.downcase]
             codename    = `lsb_release -c -s`.strip.downcase
             version     = `lsb_release -r -s`.strip.downcase
 


### PR DESCRIPTION
On my _Debian Jessie_, the os-autodetection returns `debian, 8.0`, which is wrong in the way that our osdeps use `jessie` or `sid` -- not the release-number.

The file `/etc/debian_version` does not contain something like `sid` on a current _debian-unstable_, only the actual release number like `8.0`. But I'm not sure if this changes once Debian leaves the current feature-freeze...

Well, this is my shot.

It could be argued that it is unfeasible to track a moving target like `sid` in the osdeps. Also, unstable is not really officially supported...?

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>