### PR TITLE
add explicit support for renaming packages

### DIFF
--- a/lib/autoproj/autobuild.rb
+++ b/lib/autoproj/autobuild.rb
@@ -687,3 +687,12 @@ def remove_from_default(*names)
     end
 end
 
+def renamed_package(current_name, old_name, options)
+    if options[:obsolete] && !Autoproj.manifest.explicitely_selected_in_layout?(old_name)
+        import_package old_name
+        Autoproj.manifest.add_exclusion old_name, "#{old_name} has been renamed to #{current_name}, you still have the option of using the old name by adding '- #{old_name}' explicitely in the layout in autoproj/manifest, but be warned that the name will stop being usable at all in the near future"
+    else
+        metapackage old_name, current_name
+    end
+end
+

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -231,6 +231,16 @@ module Autoproj
             end
         end
 
+        # Returns true if the given package name has been explicitely added to
+        # the layout (not indirectly)
+        #
+        # @param [String] package_name
+        # @return [Boolean]
+        def explicitely_selected_in_layout?(package_name)
+            package_name = package_name.to_str
+            normalized_layout.has_key?(package_name)
+        end
+
         # True if the given package should not be built and its dependencies
         # should be considered as met.
         #
@@ -239,7 +249,7 @@ module Autoproj
         def excluded?(package_name)
             package_name = package_name.to_str
 
-            if normalized_layout.has_key?(package_name)
+            if explicitely_selected_in_layout?(package_name)
                 false
             elsif excluded_in_manifest?(package_name)
                 true


### PR DESCRIPTION
This adds support for renaming packages explicitely instead of
directly accessing the metapackage creation. Moreover, it also
adds support to obsolete an old name (generating an error).
