### PR TITLE
homebrew: compatibility fix brew 0.9.5

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -827,12 +827,7 @@ fi
                 packages = packages.uniq
                 result = `brew info --json=v1 '#{packages.join("' '")}'`
                 result = begin
-                             result = JSON.parse(result)
-                             if packages.size == 1
-                                 [result]
-                             else
-                                 result
-                             end
+                             JSON.parse(result)
                          rescue JSON::ParserError
                              if result && !result.empty?
                                  Autoproj.warn "Error while parsing result of brew info --json=v1"
@@ -2932,7 +2927,7 @@ build-essential:
   - glibc-devel
   darwin: ignore
   opensuse:
-  - "@devel_C_C++"
+  - '@devel_C_C++'
   - gcc-c++
 autobuild:
 - gem: autobuild

--- a/lib/autoproj/osdeps.rb
+++ b/lib/autoproj/osdeps.rb
@@ -312,12 +312,7 @@ fi
                 packages = packages.uniq
                 result = `brew info --json=v1 '#{packages.join("' '")}'`
                 result = begin
-                             result = JSON.parse(result)
-                             if packages.size == 1
-                                 [result]
-                             else
-                                 result
-                             end
+                             JSON.parse(result)
                          rescue JSON::ParserError
                              if result && !result.empty?
                                  Autoproj.warn "Error while parsing result of brew info --json=v1"


### PR DESCRIPTION
homebrew is no longer returning different types depending on the number
of packages