### PR TITLE
Handle non git main configurations in update log (fixes #61)

### DIFF
--- a/lib/autoproj/cmdline.rb
+++ b/lib/autoproj/cmdline.rb
@@ -773,13 +773,12 @@ module Autoproj
             return all_enabled_packages
 
         ensure
-            if !updated_packages.empty?
+            if Autoproj.config.import_log_enabled? && !updated_packages.empty?
                 failure_message =
                     if $!
                         " (#{$!.message.split("\n").first})"
                     end
                 ops = Ops::Snapshot.new(manifest, keep_going: true)
-
                 ops.update_package_import_state(
                     "#{$0} #{argv.join(" ")}#{failure_message}",
                     updated_packages)

--- a/lib/autoproj/cmdline.rb
+++ b/lib/autoproj/cmdline.rb
@@ -773,7 +773,7 @@ module Autoproj
             return all_enabled_packages
 
         ensure
-            if Autoproj.config.import_log_enabled? && !updated_packages.empty?
+            if Autoproj.config.import_log_enabled? && !updated_packages.empty? && Autoproj::Ops::Snapshot.update_log_available?(manifest)
                 failure_message =
                     if $!
                         " (#{$!.message.split("\n").first})"

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -167,6 +167,14 @@ module Autoproj
             end
         end
 
+        def import_log_enabled?
+            get('import_log_enabled', true)
+        end
+
+        def import_log_enabled=(value)
+            set('import_log_enabled', !!value)
+        end
+
         def ruby_executable
             @ruby_executable ||= OSDependencies.autodetect_ruby_program
         end

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -113,7 +113,7 @@ module Autoproj
         attr_reader :metapackages
 
         # The VCS object for the main configuration itself
-        attr_reader :vcs
+        attr_accessor :vcs
 
         # The definition of all OS packages available on this installation
         attr_reader :osdeps
@@ -141,6 +141,7 @@ module Autoproj
             if Autoproj.has_config_key?('manifest_source')
                 @vcs = VCSDefinition.from_raw(Autoproj.user_config('manifest_source'))
             end
+            @package_sets << LocalPackageSet.new(self, vcs)
 	end
 
 

--- a/lib/autoproj/ops/configuration.rb
+++ b/lib/autoproj/ops/configuration.rb
@@ -340,7 +340,7 @@ module Autoproj
             Tools.load_main_initrb(manifest)
             manifest.load(manifest_path)
 
-            root_pkg_set = LocalPackageSet.new(manifest)
+            root_pkg_set = manifest.local_package_set
             root_pkg_set.load_description_file
             root_pkg_set.explicit = true
             package_sets = load_and_update_package_sets(root_pkg_set, only_local)

--- a/lib/autoproj/ops/main_config_switcher.rb
+++ b/lib/autoproj/ops/main_config_switcher.rb
@@ -88,6 +88,8 @@ module Autoproj
                 return args, reuse
             end
 
+            MAIN_CONFIGURATION_TEMPLATE = File.expand_path(File.join("..", "..", "..", "samples", 'autoproj'), File.dirname(__FILE__))
+
             def bootstrap(*args)
                 check_root_dir_empty
                 args, reuse = handle_bootstrap_options(args)
@@ -113,8 +115,7 @@ module Autoproj
                 # If we are not getting the installation setup from a VCS, copy the template
                 # files
                 if args.empty? || args.size == 1
-                    sample_dir = File.expand_path(File.join("..", "..", "..", "samples"), File.dirname(__FILE__))
-                    FileUtils.cp_r File.join(sample_dir, "autoproj"), "autoproj"
+                    FileUtils.cp_r MAIN_CONFIGURATION_TEMPLATE, "autoproj"
                 end
 
                 if args.size == 1 # the user asks us to download a manifest

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -44,7 +44,17 @@ module Autoproj
         end
 
         def setup
-            # Setup code for all the tests
+            @tmpdir = Array.new
+            super
+        end
+
+        def create_bootstrap
+            dir = Dir.mktmpdir
+            @tmpdir << dir
+            require 'autoproj/ops/main_config_switcher'
+            FileUtils.cp_r Ops::MainConfigSwitcher::MAIN_CONFIGURATION_TEMPLATE, File.join(dir, 'autoproj')
+            Autoproj.root_dir = dir
+            Autoproj.manifest = Manifest.load(File.join(dir, 'autoproj', 'manifest'))
         end
 
         def teardown
@@ -52,6 +62,9 @@ module Autoproj
                 flexmock_teardown
             end
             super
+            @tmpdir.each do |dir|
+                FileUtils.remove_entry_secure dir
+            end
             Autobuild::Package.clear
         end
     end

--- a/test/ops/test_snapshot.rb
+++ b/test/ops/test_snapshot.rb
@@ -1,0 +1,26 @@
+require 'autoproj/test'
+
+module Autoproj
+    module Ops
+        describe Snapshot do
+            attr_reader :manifest
+            before do
+                @manifest = create_bootstrap
+            end
+
+            describe ".update_log_available?" do
+                it "returns false if the main configuration is not managed by git" do
+                    assert !Snapshot.update_log_available?(manifest)
+                end
+                it "returns true if the main configuration is managed by git even if it is not declared" do
+                    system("git", "init", chdir: Autoproj.config_dir, STDOUT => :close)
+                    assert Snapshot.update_log_available?(manifest)
+                end
+                it "returns true if the main configuration is managed by git and it is declared" do
+                    manifest.main_package_set.vcs = VCSDefinition.from_raw('type' => 'git', 'url' => Autoproj.config_dir)
+                    assert Snapshot.update_log_available?(manifest)
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
This properly handles main configurations that are either not a git, or are a git repository but that is not declared in config.yml