### PR TITLE
Make repository id equal to the url it is referring to

### DIFF
--- a/lib/autoproj/gitorious.rb
+++ b/lib/autoproj/gitorious.rb
@@ -93,7 +93,7 @@ module Autoproj
                  url: "#{pull_base_url}#{url}",
                  push_to: "#{push_base_url}#{url}",
                  retry_count: 10,
-                 repository_id: "#{name.downcase}:#{url}"].merge(vcs_options)
+                 repository_id: "#{url}"].merge(vcs_options)
         end
     end
 end


### PR DESCRIPTION
Otherwise multiple configurations (e.g. to legacy naming in package_sets) which refer to the same url lead
to broken links under autoproj/remotes/.


This might not be the best fix for the given issue so @doudou let me know in case there is a better place to fix this.
In  the current situation there are two such definitions, but only one package_set is found under .remotes and the symlink points to the not-existing one.