### PR TITLE
Homebrew: ignore package sudo

### DIFF
--- a/lib/autoproj/default.osdeps
+++ b/lib/autoproj/default.osdeps
@@ -207,6 +207,7 @@ pip:
   freebsd: pip
 
 sudo:
+  macos-brew: ignore
   default: sudo
 
 # vim: expandtab


### PR DESCRIPTION
Homebrew does not need root access to install new packages.
Furthermore, there exists no formular called 'sudo'