### PR TITLE
Print bootstrap 'success' message to stdout rather than to stderr

### DIFF
--- a/lib/autoproj/cli/bootstrap.rb
+++ b/lib/autoproj/cli/bootstrap.rb
@@ -46,7 +46,7 @@ module Autoproj
                         FileUtils.cp seed_config, File.join(ws.config_dir, 'config.yml')
                     end
 
-                    STDERR.puts <<-EOTEXT
+                    STDOUT.puts <<-EOTEXT
 
 
 #{Autoproj.color('autoproj bootstrap successfully finished', :green, :bold)}


### PR DESCRIPTION
Since this is not an error message and is not ciritical, couldn't it be printed to stdout? This would be better for automated setups.