### PR TITLE
avoid leaking backtraces to users, for errors that are most likely caused by them

### DIFF
--- a/lib/autoproj/cli.rb
+++ b/lib/autoproj/cli.rb
@@ -1,6 +1,15 @@
 module Autoproj
     module CLI
-        class InvalidArguments < Exception
+        class CLIException < RuntimeError
+            def fatal?
+                true
+            end
+        end
+        class CLIInvalidArguments < CLIException
+        end
+        class CLIAmbiguousArguments < CLIException
+        end
+        class CLIInvalidSelection < CLIException
         end
 
         def self.load_plugins

--- a/lib/autoproj/cli/bootstrap.rb
+++ b/lib/autoproj/cli/bootstrap.rb
@@ -12,7 +12,7 @@ module Autoproj
 
             def initialize(root_dir = Dir.pwd)
                 if File.exist?(File.join(root_dir, 'autoproj', "manifest"))
-                    raise ConfigError, "this installation is already bootstrapped. Remove the autoproj directory if it is not the case"
+                    raise CLIException, "this installation is already bootstrapped. Remove the autoproj directory if it is not the case"
                 end
                 @root_dir = root_dir
             end
@@ -26,7 +26,7 @@ module Autoproj
 
                     path = File.expand_path(path)
                     if !File.directory?(path) || !File.directory?(File.join(path, 'autoproj'))
-                        raise ArgumentError, "#{path} does not look like an autoproj installation"
+                        raise CLIInvalidArguments, "#{path} does not look like an autoproj installation"
                     end
                     options[:reuse] = [path]
                 end

--- a/lib/autoproj/cli/cache.rb
+++ b/lib/autoproj/cli/cache.rb
@@ -10,12 +10,12 @@ module Autoproj
                 if argv.empty?
                     default_cache_dirs = Autobuild::Importer.default_cache_dirs
                     if !default_cache_dirs || default_cache_dirs.empty?
-                        raise ArgumentError, "no cache directory defined with e.g. the AUTOBUILD_CACHE_DIR environment variable, expected one cache directory as argument"
+                        raise CLIInvalidArguments, "no cache directory defined with e.g. the AUTOBUILD_CACHE_DIR environment variable, expected one cache directory as argument"
                     end
                     Autoproj.warn "using cache directory #{default_cache_dirs.first} from the autoproj configuration"
                     argv << default_cache_dirs.first
                 elsif argv.size > 1
-                    raise ArgumentError, "expected only one cache directory as argument"
+                    raise CLIInvalidArguments, "expected only one cache directory as argument"
                 end
 
                 return File.expand_path(argv.first, ws.root_dir), options

--- a/lib/autoproj/cli/clean.rb
+++ b/lib/autoproj/cli/clean.rb
@@ -29,7 +29,7 @@ module Autoproj
                     packages,
                     recursive: deps)
                 if source_packages.empty?
-                    raise ArgumentError, "no packages or OS packages match #{selection.join(" ")}"
+                    raise CLIInvalidArguments, "no packages or OS packages match #{selection.join(" ")}"
                 end
 
                 source_packages.each do |pkg_name|

--- a/lib/autoproj/cli/commit.rb
+++ b/lib/autoproj/cli/commit.rb
@@ -9,7 +9,7 @@ module Autoproj
                 pkg = manifest.main_package_set.create_autobuild_package
                 importer = pkg.importer
                 if !importer || !importer.kind_of?(Autobuild::Git)
-                    raise ConfigError, "cannot use autoproj tag if the main configuration is not managed by git"
+                    raise CLIInvalidArguments, "cannot use autoproj tag if the main configuration is not managed by git"
                 end
 
                 versions_file = File.join(

--- a/lib/autoproj/cli/log.rb
+++ b/lib/autoproj/cli/log.rb
@@ -34,7 +34,7 @@ module Autoproj
                 elsif entry =~ /^\d+$/
                     "autoproj@{#{entry}}"
                 else
-                    raise ArgumentError, "unexpected revision name '#{entry}', expected either autoproj@{ID} or ID ('ID' being a number). Run 'autoproj log' without arguments for a list of known entries"
+                    raise CLIInvalidArguments, "unexpected revision name '#{entry}', expected either autoproj@{ID} or ID ('ID' being a number). Run 'autoproj log' without arguments for a list of known entries"
                 end
             end
         end

--- a/lib/autoproj/cli/main_plugin.rb
+++ b/lib/autoproj/cli/main_plugin.rb
@@ -37,7 +37,7 @@ module Autoproj
 
                 gem_options = Hash.new
                 if options[:git] && options[:path]
-                    raise ArgumentError, "you can provide only one of --git or --path"
+                    raise CLIInvalidArguments, "you can provide only one of --git or --path"
                 elsif options[:git]
                     gem_options[:git] = options[:git]
                 elsif options[:path]

--- a/lib/autoproj/cli/manifest.rb
+++ b/lib/autoproj/cli/manifest.rb
@@ -15,7 +15,7 @@ module Autoproj
                     name = name.first
                     if File.file?(full_path = File.expand_path(name))
                         if File.dirname(full_path) != ws.config_dir
-                            raise ArgumentError, "#{full_path} is not part of #{ws.config_dir}"
+                            raise CLIInvalidArguments, "#{full_path} is not part of #{ws.config_dir}"
                         end
                     else
                         full_path = File.join(ws.config_dir, name)
@@ -24,7 +24,7 @@ module Autoproj
                     if !File.file?(full_path)
                         alternative_full_path = File.join(ws.config_dir, "manifest.#{name}")
                         if !File.file?(alternative_full_path)
-                            raise ArgumentError, "neither #{full_path} nor #{alternative_full_path} exist"
+                            raise CLIInvalidArguments, "neither #{full_path} nor #{alternative_full_path} exist"
                         end
                         full_path = alternative_full_path
                     end
@@ -38,8 +38,11 @@ module Autoproj
                     ws.save_config
                     Autoproj.message "set manifest to #{full_path}"
                 else
-                    raise ArgumentError, "expected zero or one argument, but got #{name.size}"
+                    raise CLIInvalidArguments, "expected zero or one argument, but got #{name.size}"
                 end
+            end
+
+            def notify_env_sh_updated
             end
         end
     end

--- a/lib/autoproj/cli/reset.rb
+++ b/lib/autoproj/cli/reset.rb
@@ -10,14 +10,14 @@ module Autoproj
                 pkg = manifest.main_package_set.create_autobuild_package
                 importer = pkg.importer
                 if !importer || !importer.kind_of?(Autobuild::Git)
-                    raise ConfigError, "cannot use autoproj reset if the main configuration is not managed by git"
+                    raise CLIInvalidArguments, "cannot use autoproj reset if the main configuration is not managed by git"
                 end
                 
                 # Check if the reflog entry exists
                 begin
                     importer.rev_parse(pkg, ref_name)
                 rescue Autobuild::PackageException
-                    raise InvalidArguments, "#{ref_name} does not exist, run autoproj log for log entries and autoproj tag without arguments for the tags"
+                    raise CLIInvalidArguments, "#{ref_name} does not exist, run autoproj log for log entries and autoproj tag without arguments for the tags"
                 end
 
                 # Checkout the version file

--- a/lib/autoproj/cli/snapshot.rb
+++ b/lib/autoproj/cli/snapshot.rb
@@ -30,7 +30,7 @@ module Autoproj
                 # This must be done first as the snapshot calls might copy stuff in
                 # there
                 if File.exist?(target_dir)
-                    raise ArgumentError, "#{target_dir} already exists"
+                    raise CLIInvalidArguments, "#{target_dir} already exists"
                 end
                 FileUtils.cp_r Autoproj.config_dir, target_dir
 

--- a/lib/autoproj/cli/switch_config.rb
+++ b/lib/autoproj/cli/switch_config.rb
@@ -9,9 +9,9 @@ module Autoproj
         class SwitchConfig < Base
             def run(args, options = Hash.new)
                 if !File.directory?(ws.config_dir)
-                    raise ConfigError, "there's no autoproj/ directory in this workspace, use autoproj bootstrap to check out one"
+                    raise CLIInvalidArguments, "there's no autoproj/ directory in this workspace, use autoproj bootstrap to check out one"
                 elsif Dir.pwd.start_with?(ws.remotes_dir) || Dir.pwd.start_with?(ws.config_dir)
-                    raise ConfigError, "you cannot run autoproj switch-config from autoproj's configuration directory or one of its subdirectories"
+                    raise CLIInvalidArguments, "you cannot run autoproj switch-config from autoproj's configuration directory or one of its subdirectories"
                 end
 
                 ws.load_config

--- a/lib/autoproj/cli/tag.rb
+++ b/lib/autoproj/cli/tag.rb
@@ -14,7 +14,7 @@ module Autoproj
                 pkg = main_package_set.create_autobuild_package
                 importer = pkg.importer
                 if !importer || !importer.kind_of?(Autobuild::Git)
-                    raise ConfigError, "cannot use autoproj tag if the main configuration is not managed by git"
+                    raise CLIInvalidArguments, "cannot use autoproj tag if the main configuration is not managed by git"
                 end
 
                 versions_file = File.join(
@@ -37,7 +37,7 @@ module Autoproj
                 # Check if the tag already exists
                 begin
                     importer.rev_parse(pkg, "refs/tags/#{tag_name}")
-                    raise InvalidArguments, "tag #{tag_name} already exists"
+                    raise CLIInvalidArguments, "tag #{tag_name} already exists"
                 rescue Autobuild::PackageException
                 end
 

--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -198,6 +198,8 @@ module Autoproj
                                         install_vcs_packages: (osdeps_options if osdeps),
                                         auto_exclude: auto_exclude)
                 return source_packages, osdep_packages, nil
+            rescue ExcludedSelection => e
+                raise CLIInvalidSelection, e.message, e.backtrace
             rescue PackageImportFailed => import_failure
                 if !keep_going
                     raise

--- a/lib/autoproj/exceptions.rb
+++ b/lib/autoproj/exceptions.rb
@@ -36,6 +36,9 @@ module Autoproj
     class UnregisteredPackage < ArgumentError
     end
 
+    class UnregisteredPackageSet < ArgumentError
+    end
+
     class InvalidPackageManifest < RuntimeError; end
 
     class InputError < RuntimeError; end

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -240,7 +240,7 @@ module Autoproj
         #
         # Validate that the given package object is defined in self
         def validate_package_set_in_self(package_set)
-            if find_package_set(package.name) != package_set
+            if find_package_set(package_set.name) != package_set
                 raise UnregisteredPackageSet, "#{package_set.name} is not registered on #{self}"
             end
         end

--- a/lib/autoproj/reporter.rb
+++ b/lib/autoproj/reporter.rb
@@ -88,6 +88,18 @@ module Autoproj
                 package_failures, on_package_failures: on_package_failures, interrupted_by: interrupted)
         end
 
+    rescue CLI::CLIException => e
+        if silent_errors
+            return [e]
+        elsif on_package_failures == :raise
+            raise e
+        elsif on_package_failures == :report
+            Autoproj.error e.message
+        elsif on_package_failures == :exit
+            Autoproj.error e.message
+            exit 1
+        end
+
     rescue SystemExit
         raise
     ensure

--- a/test/cli/test_base.rb
+++ b/test/cli/test_base.rb
@@ -3,17 +3,36 @@ require 'autoproj/cli/base'
 module Autoproj
     module CLI
         describe Base do
-            describe "#resolve_user_selection" do
-                attr_reader :ws, :base
-                before do
-                    @ws = ws_create
-                    @base = Base.new(ws)
-                end
-                after do
-                    Autoproj.verbose = false
-                end
+            attr_reader :ws, :base
+            before do
+                @ws = ws_create
+                @base = Base.new(ws)
+            end
+            after do
+                Autoproj.verbose = false
+            end
 
+            describe "#resolve_user_selection" do
                 describe "empty user selection" do
+                    it "raises CLIInvalidSelection if an excluded package is selected" do
+                        ws_add_package_to_layout :cmake, 'pkg0'
+                        @ws.manifest.exclude_package 'pkg0', 'test'
+                        assert_raises(CLIInvalidSelection) do
+                            @base.resolve_user_selection([])
+                        end
+                    end
+
+                    it "raises CLIInvalidSelection if a package set that depends on an excluded package is being selected" do
+                        pkg_set = ws_add_package_set_to_layout 'test'
+                        pkg0 = ws_define_package :cmake, 'pkg0'
+                        @ws.manifest.metapackage 'test', 'pkg0'
+                        @ws.manifest.exclude_package 'pkg0', 'test'
+
+                        assert_raises(CLIInvalidSelection) do
+                            @base.resolve_user_selection([])
+                        end
+                    end
+
                     it "returns all the selected packages if called without a user selection" do
                         ws_add_package_to_layout :cmake, 'pkg0'
                         ws_add_package_to_layout :cmake, 'pkg1'
@@ -33,6 +52,14 @@ module Autoproj
                 end
 
                 describe "explicit user selection" do
+                    it "raises CLIInvalidSelection if an excluded package is selected" do
+                        ws_add_package_to_layout :cmake, 'pkg0'
+                        @ws.manifest.exclude_package 'pkg0', 'test'
+                        assert_raises(CLIInvalidSelection) do
+                            @base.resolve_user_selection(['pkg0'])
+                        end
+                    end
+
                     it "uses the manifest to resolve the user strings into package names" do
                         user_selection = flexmock(empty?: false)
                         user_selection.should_receive(:to_set).and_return(user_selection)
@@ -40,6 +67,10 @@ module Autoproj
                             once.with(user_selection, Hash).
                             and_return([expanded_selection = flexmock, []])
                         assert_equal [expanded_selection, []], base.resolve_user_selection(user_selection) 
+                    end
+                    it "returns the list of unmatched strings" do
+                        _, unmatched = @base.resolve_user_selection(['does_not_exist'])
+                        assert_equal ['does_not_exist'], unmatched.to_a
                     end
                     it "displays the packages to be installed if verbose is set" do
                         Autoproj.verbose = true
@@ -83,6 +114,20 @@ module Autoproj
                         autobuild_package = ws.manifest.find_autobuild_package('path/to/package')
                         assert_kind_of Autobuild::CMake, autobuild_package
                         assert_equal package_path, autobuild_package.srcdir
+                    end
+                end
+            end
+
+            describe "#resolve_selection" do
+                it "raises CLIInvalidSelection if a package depends on an excluded package" do
+                    pkg0 = ws_add_package_to_layout :cmake, 'pkg0'
+                    pkg1 = ws_define_package :cmake, 'pkg1'
+                    pkg0.depends_on pkg1
+                    selection = PackageSelection.new
+                    selection.select('pkg0', 'pkg0')
+                    @ws.manifest.exclude_package 'pkg1', 'test'
+                    assert_raises(CLIInvalidSelection) do
+                        @base.resolve_selection(selection)
                     end
                 end
             end

--- a/test/cli/test_tag.rb
+++ b/test/cli/test_tag.rb
@@ -1,0 +1,21 @@
+require 'autoproj/test'
+require 'autoproj/cli/tag'
+module Autoproj
+    module CLI
+        describe Tag do
+            it "raises CLIInvalidArguments if the main build configuration does not have an importer" do
+                ws_create
+                assert_raises(CLIInvalidArguments) do
+                    Tag.new(ws).run('tagname')
+                end
+            end
+            it "raises CLIInvalidArguments if the main build configuration's importer is not git" do
+                ws_create
+                assert_raises(CLIInvalidArguments) do
+                    Tag.new(ws).run('tagname')
+                end
+            end
+        end
+    end
+end
+

--- a/test/cli/test_update.rb
+++ b/test/cli/test_update.rb
@@ -204,6 +204,17 @@ module Autoproj
                         and_return([[], []])
                     cli.run([], packages: true, checkout_only: true, osdeps: true)
                 end
+                it "raises CLIInvalidSelection if an excluded package is in the dependency tree" do
+                    pkg0 = ws_add_package_to_layout :cmake, 'pkg0'
+                    pkg1 = ws_define_package :cmake, 'pkg1'
+                    pkg0.depends_on pkg1
+                    selection = PackageSelection.new
+                    selection.select('pkg0', 'pkg0')
+                    @ws.manifest.exclude_package 'pkg1', 'test'
+                    assert_raises(CLIInvalidSelection) do
+                        cli.run(['pkg0'], packages: true, checkout_only: true, osdeps: true)
+                    end
+                end
 
                 describe "keep_going: false" do
                     it "passes exceptions from package set updates" do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -741,6 +741,24 @@ module Autoproj
                 manifest.load_importers(mainline: true)
             end
         end
+
+        describe "validate_package_set_in_self" do
+            it "returns if the package set is defined in self" do
+                pkg_set = ws_define_package_set "pkg_set"
+                @ws.manifest.validate_package_set_in_self(pkg_set)
+            end
+            it "raises if there are no package sets with the given name in self" do
+                assert_raises(UnregisteredPackageSet) do
+                    @ws.manifest.validate_package_set_in_self(flexmock(name: 'test'))
+                end
+            end
+            it "raises if there is a different package set in self with the same name" do
+                pkg_set = ws_define_package_set "pkg_set"
+                assert_raises(UnregisteredPackageSet) do
+                    @ws.manifest.validate_package_set_in_self(flexmock(name: 'test'))
+                end
+            end
+        end
     end
 end
 


### PR DESCRIPTION
All CLI errors that are not internal errors are now subclasses of
CLIException (the same way that Autobuild errors are subclasses of
ConfigError). This ensures that we can rescue the error and show it
without a backtrace at the root.