### PR TITLE
fix type error leading to error message: package_managers/shell_scrip…

### DIFF
--- a/lib/autoproj/package_managers/zypper_manager.rb
+++ b/lib/autoproj/package_managers/zypper_manager.rb
@@ -29,8 +29,8 @@ module Autoproj
                 result = false
                 if !patterns.empty?
                     result |= super(patterns,
-                                    auto_install_cmd: "zypper --non-interactive install --type pattern '%s'",
-                                    user_install_cmd: "zypper install --type pattern '%s'")
+                                    auto_install_cmd: %w{zypper --non-interactive install --type pattern},
+                                    user_install_cmd: %w{zypper install --type pattern})
                 end
                 if !packages.empty?
                     result |= super(packages)


### PR DESCRIPTION
…t_manager.rb:118:in `generate_auto_os_script': undefined method `join' for "zypper --non-interactive install --type pattern '%s'":String (NoMethodError)

Not 100% sure if the type is now as intended. Other package managers should be checked for this problem, too.