### PR TITLE
cli: refactor which and exec to optionally use an env cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 /coverage/
 /.yardoc/
 test/gem_home
+tmp/

--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "flexmock", '~> 2.0', ">= 2.0.0"
     s.add_development_dependency "minitest", "~> 5.0", ">= 5.0"
     s.add_development_dependency "simplecov"
+    s.add_development_dependency "aruba"
 end
 

--- a/lib/autoproj.rb
+++ b/lib/autoproj.rb
@@ -35,9 +35,12 @@ require 'autoproj/query_base'
 require 'autoproj/source_package_query'
 require 'autoproj/os_package_query'
 
+require 'autoproj/ops/install'
 require 'autoproj/ops/tools'
 require 'autoproj/ops/loader'
 require 'autoproj/ops/configuration'
+require 'autoproj/ops/cached_env'
+require 'autoproj/ops/which'
 
 require 'autoproj/workspace'
 

--- a/lib/autoproj/aruba_minitest.rb
+++ b/lib/autoproj/aruba_minitest.rb
@@ -1,0 +1,66 @@
+require 'aruba/api'
+
+module Autoproj
+    # Minitest-usable Aruba wrapper
+    #
+    # Aruba 0.14 is incompatible with Minitest because of their definition
+    # of the #run method This change hacks around the problem, by moving
+    # the Aruba API to a side stub object.
+    #
+    # The run methods are renamed as they have been renamed in Aruba 1.0
+    # alpha, run -> run_command and run_simple -> run_command_and_stop
+    module ArubaMinitest
+        class API
+            include ::Aruba::Api
+        end
+
+        def setup
+            super
+            @aruba_api = API.new
+            @aruba_api.setup_aruba
+        end
+
+        def teardown
+            stop_all_commands
+            super
+        end
+
+        def run_command_and_stop(*args, fail_on_error: true)
+            cmd = run_command(*args)
+            cmd.stop
+            if fail_on_error
+                assert_command_finished_successfully(cmd)
+            end
+            cmd
+        end
+
+        def run_command(*args)
+            @aruba_api.run(*args)
+        end
+
+        def chmod(*args) # also defined by Rake
+            @aruba_api.chmod(*args)
+        end
+
+        def method_missing(m, *args, &block)
+            if @aruba_api.respond_to?(m)
+                return @aruba_api.send(m, *args, &block)
+            else
+                super
+            end
+        end
+
+        def assert_command_stops(cmd, fail_on_error: true)
+            cmd.stop
+            if fail_on_error
+                assert_command_finished_successfully(cmd)
+            end
+        end
+
+        def assert_command_finished_successfully(cmd)
+            refute cmd.timed_out?, "#{cmd} timed out on stop"
+            assert_equal 0, cmd.exit_status, "#{cmd} finished with a non-zero exit status (#{cmd.exit_status})\n-- STDOUT\n#{cmd.stdout}\n-- STDERR\n#{cmd.stderr}"
+        end
+    end
+end
+

--- a/lib/autoproj/cli/exec.rb
+++ b/lib/autoproj/cli/exec.rb
@@ -1,21 +1,55 @@
-require 'autoproj/cli/inspection_tool'
+require 'autoproj/find_workspace'
+require 'autoproj/ops/cached_env'
+require 'autoproj/ops/which'
+
 module Autoproj
     module CLI
-        class Exec < InspectionTool
-            def run(cmd, *args)
-                initialize_and_load
-                finalize_setup(Array.new)
+        class Exec
+            def initialize
+                @root_dir = Autoproj.find_workspace_dir
+                if !@root_dir
+                    require 'autoproj/workspace'
+                    # Will do all sorts of error reporting,
+                    # or may be able to resolve
+                    @root_dir = Workspace.default.root_dir
+                end
+            end
 
+            def load_cached_env
+                env = Ops.load_cached_env(@root_dir)
+                return if !env
+
+                Autobuild::Environment.
+                    environment_from_export(env, ENV)
+            end
+
+            def run(cmd, *args, use_cached_env: false)
+                if use_cached_env
+                    env = load_cached_env
+                end
+
+                if !env
+                    require 'autoproj'
+                    require 'autoproj/cli/inspection_tool'
+                    ws = Workspace.from_dir(@root_dir)
+                    loader = InspectionTool.new(ws)
+                    loader.initialize_and_load
+                    loader.finalize_setup(Array.new)
+                    env = ws.full_env.resolved_env
+                end
+
+                path = env['PATH'].split(File::PATH_SEPARATOR)
                 program = 
-                    begin ws.which(cmd)
+                    begin Ops.which(cmd, path_entries: path)
                     rescue ::Exception => e
+                        require 'autoproj'
                         raise CLIInvalidArguments, e.message, e.backtrace
                     end
-                env = ws.full_env.resolved_env
 
                 begin
                     ::Process.exec(env, program, *args)
                 rescue ::Exception => e
+                    require 'autoproj'
                     raise CLIInvalidArguments, e.message, e.backtrace
                 end
             end

--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'tty/color'
 require 'autoproj/cli/main_test'
 require 'autoproj/cli/main_plugin'
+require 'autoproj/reporter'
 
 module Autoproj
     module CLI
@@ -453,15 +454,23 @@ The format is a string in which special values can be expanded using a $VARNAME 
             end
 
             desc 'exec', "runs a command, applying the workspace's environment first"
+            option :use_cache, type: :boolean, desc: 'use the cached environment instead of loading "\
+                " the whole configuration'
             def exec(*args)
                 require 'autoproj/cli/exec'
-                CLI::Exec.new.run(*args)
+                Autoproj.report(on_package_failures: default_report_on_package_failures, debug: options[:debug], silent: true) do
+                    CLI::Exec.new.run(*args, use_cached_env: options[:use_cache])
+                end
             end
 
             desc 'which', "resolves the full path to a command within the Autoproj workspace"
+            option :use_cache, type: :boolean, desc: 'use the cached environment instead of loading "\
+                " the whole configuration'
             def which(cmd)
                 require 'autoproj/cli/which'
-                CLI::Which.new.run(cmd)
+                Autoproj.report(on_package_failures: default_report_on_package_failures, debug: options[:debug], silent: true) do
+                    CLI::Which.new.run(cmd, use_cached_env: options[:use_cache])
+                end
             end
         end
     end

--- a/lib/autoproj/cli/which.rb
+++ b/lib/autoproj/cli/which.rb
@@ -1,14 +1,51 @@
-require 'autoproj/cli/inspection_tool'
+require 'autoproj'
+require 'autoproj/ops/cached_env'
+require 'autoproj/ops/which'
+
 module Autoproj
     module CLI
-        class Which < InspectionTool
-            def run(cmd)
-                initialize_and_load
-                finalize_setup(Array.new)
+        class Which
+            def initialize
+                @root_dir = Autoproj.find_workspace_dir
+                if !@root_dir
+                    require 'autoproj/workspace'
+                    # Will do all sorts of error reporting,
+                    # or may be able to resolve
+                    @root_dir = Workspace.default.root_dir
+                end
+            end
 
-                puts ws.which(cmd)
-            rescue Workspace::ExecutableNotFound => e
+            def load_cached_env
+                env = Ops.load_cached_env(@root_dir)
+                return if !env
+
+                Autobuild::Environment.
+                    environment_from_export(env, ENV)
+            end
+
+            def run(cmd, use_cached_env: false)
+                if use_cached_env
+                    env = load_cached_env
+                end
+
+                if !env
+                    require 'autoproj'
+                    require 'autoproj/cli/inspection_tool'
+                    ws = Workspace.from_dir(@root_dir)
+                    loader = InspectionTool.new(ws)
+                    loader.initialize_and_load
+                    loader.finalize_setup(Array.new)
+                    env = ws.full_env.resolved_env
+                end
+
+                path = env['PATH'].split(File::PATH_SEPARATOR)
+                puts Ops.which(cmd, path_entries: path)
+            rescue ExecutableNotFound => e
+                require 'autoproj' # make sure everything is available for error reporting
                 raise CLIInvalidArguments, e.message, e.backtrace
+            rescue Exception
+                require 'autoproj' # make sure everything is available for error reporting
+                raise
             end
         end
     end

--- a/lib/autoproj/exceptions.rb
+++ b/lib/autoproj/exceptions.rb
@@ -1,3 +1,5 @@
+require 'autobuild/exceptions'
+
 module Autoproj
     class ConfigError < RuntimeError
         attr_accessor :file
@@ -84,6 +86,9 @@ module Autoproj
     # Exception raised when initializing on a workspace that is not the current
     # one
     class MismatchingWorkspace < InvalidWorkspace; end
+
+    # Raised by 'which' when an executable cannot be found
+    class ExecutableNotFound < ArgumentError; end
 end
 
 

--- a/lib/autoproj/ops/cached_env.rb
+++ b/lib/autoproj/ops/cached_env.rb
@@ -1,0 +1,36 @@
+require 'autobuild/environment'
+
+module Autoproj
+    module Ops
+        def self.cached_env_path(root_dir)
+            File.join(root_dir, '.autoproj', 'env.yml')
+        end
+
+        def self.load_cached_env(root_dir)
+            path = cached_env_path(root_dir)
+            if File.file?(path)
+                env = YAML.load(File.read(path))
+                Autobuild::Environment::ExportedEnvironment.new(
+                    env['set'], env['unset'], env['update'])
+            end
+        end
+
+        def self.save_cached_env(root_dir, env)
+            env = env.exported_environment
+            path = cached_env_path(root_dir)
+            existing =
+                begin
+                    YAML.load(File.read(path))
+                rescue Exception
+                end
+
+            env = Hash['set' => env.set, 'unset' => env.unset, 'update' => env.update]
+            if env != existing
+                Ops.atomic_write(path) do |io|
+                    YAML.dump(env, io)
+                end
+                true
+            end
+        end
+    end
+end

--- a/lib/autoproj/ops/which.rb
+++ b/lib/autoproj/ops/which.rb
@@ -1,0 +1,45 @@
+require 'pathname'
+require 'autoproj/exceptions'
+require 'autobuild/environment'
+
+module Autoproj
+    module Ops
+        # Find the given executable file in PATH
+        #
+        # If `cmd` is an absolute path, it will either return it or raise if
+        # `cmd` is not executable. Otherwise, looks for an executable named
+        # `cmd` in PATH and returns it, or raises if it cannot be found. The
+        # exception contains a more detailed reason for failure
+        # 
+        #
+        # @param [String] cmd
+        # @return [String] the resolved program
+        # @raise [ExecutableNotFound] if an executable file named `cmd` cannot
+        #   be found
+        def self.which(cmd, path_entries: nil)
+            path = Pathname.new(cmd)
+            if path.absolute?
+                if path.file? && path.executable?
+                    return cmd
+                elsif path.exist?
+                    raise ExecutableNotFound.new(cmd), "given command `#{cmd}` exists but is not an executable file"
+                else
+                    raise ExecutableNotFound.new(cmd), "given command `#{cmd}` does not exist, an executable file was expected"
+                end
+            else
+                if path_entries.respond_to?(:call)
+                    path_entries = path_entries.call
+                end
+                absolute = Autobuild::Environment.find_executable_in_path(cmd, path_entries)
+
+                if absolute
+                    return absolute
+                elsif file = Autobuild::Environment.find_in_path(cmd, path_entries)
+                    raise ExecutableNotFound.new(cmd), "`#{cmd}` resolves to #{file} which is not executable"
+                else
+                    raise ExecutableNotFound.new(cmd), "cannot resolve `#{cmd}` to an executable in the workspace"
+                end
+            end
+        end
+    end
+end

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -271,8 +271,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
                 os_package_manager: 'os')
         end
 
-        def ws_create
-            dir = make_tmpdir
+        def ws_create(dir = make_tmpdir)
             require 'autoproj/ops/main_config_switcher'
             FileUtils.cp_r Ops::MainConfigSwitcher::MAIN_CONFIGURATION_TEMPLATE, File.join(dir, 'autoproj')
             FileUtils.mkdir_p File.join(dir, '.autoproj')

--- a/test/cli/test_exec.rb
+++ b/test/cli/test_exec.rb
@@ -1,45 +1,120 @@
 require 'autoproj/test'
+require 'autoproj/aruba_minitest'
 require 'autoproj/cli/exec'
 
 module Autoproj
     module CLI
         describe Exec do
+            include Autoproj::ArubaMinitest
             before do
-                ws_create
-                @cli = Exec.new(ws)
-                flexmock(@cli).should_receive(:initialize_and_load)
+                ws_create(expand_path('.'))
+                set_environment_variable 'AUTOPROJ_CURRENT_ROOT', ws.root_dir
+                @autoproj_bin = File.expand_path(File.join("..", "..", "bin", "autoproj"), __dir__)
+
+                write_file 'subdir/test', <<-STUB_SCRIPT
+                    #! /bin/sh
+                    echo "ARG $@"
+                    echo "ENV $TEST_ENV_VAR"
+                    STUB_SCRIPT
+                chmod 0755, 'subdir/test'
             end
 
-            it "passes the full environment, program and the arguments to the exec'd process" do
-                flexmock(ws).should_receive(:which).with("path").
-                    and_return('/resolved/path')
-                env = flexmock
-                flexmock(ws).should_receive(:full_env => flexmock(resolved_env: env))
-                flexmock(Process).should_receive(:exec).with(env, "/resolved/path", 'args').once
-                @cli.run('path', 'args')
-            end
-
-            it "re-raises any exception raised by Process as a CLIInvalidArguments" do
-                flexmock(ws).should_receive(:which).with("path").
-                    and_return('/resolved/path')
-                flexmock(Process).should_receive(:exec).
-                    and_raise(RuntimeError.new("ENOENT"))
-                e = assert_raises(CLIInvalidArguments) do
-                    @cli.run('path')
+            describe "without using the cache" do
+                before do
+                    append_to_file 'autoproj/init.rb',
+                        "Autoproj.env.set 'TEST_ENV_VAR', 'SOME_VALUE'\n"
+                    append_to_file 'autoproj/init.rb',
+                        "Autoproj.env.add_path 'PATH', '#{expand_path('subdir')}'\n"
                 end
-                assert_equal "ENOENT", e.message
+
+                it "resolves the command and execs the process with the internal environment" do
+                    cmd = run_command_and_stop "#{@autoproj_bin} exec test --some --arg"
+                    assert_equal <<-OUTPUT.chomp, cmd.stdout.chomp
+ARG --some --arg
+ENV SOME_VALUE
+                    OUTPUT
+                end
+
+                it "displays an error if the command does not exist" do
+                    cmd = run_command_and_stop "#{@autoproj_bin} exec does_not_exist --some --arg",
+                        fail_on_error: false
+                    assert_equal 1, cmd.exit_status
+                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                        cmd.stderr
+                end
             end
 
-            it "re-raises a ExecutableNotFound originally raised by Workspace#which" do
-                flexmock(ws).should_receive(:which).with("path").
-                    and_raise(Workspace::ExecutableNotFound.new("cannot find"))
-                e = assert_raises(CLIInvalidArguments) do
-                    @cli.run('path')
+            describe "while using the cache" do
+                before do
+                    path = expand_path('subdir').split(File::PATH_SEPARATOR)
+                    cache = Hash[
+                        'set' => Hash['PATH' => path, 'TEST_ENV_VAR' => ['SOME_VALUE']],
+                        'unset' => Array.new,
+                        'update' => Array.new
+                    ]
+                    write_file '.autoproj/env.yml', YAML.dump(cache)
                 end
-                assert_equal "cannot find", e.message
+
+                it "resolves the command and execs the process with the internal environment" do
+                    cmd = run_command_and_stop "#{@autoproj_bin} exec --use-cache test --some --arg"
+                    assert_equal <<-OUTPUT.chomp, cmd.stdout.chomp
+ARG --some --arg
+ENV SOME_VALUE
+                    OUTPUT
+                end
+
+                it "displays an error if the command does not exist" do
+                    cmd = run_command_and_stop "#{@autoproj_bin} exec --use-cache does_not_exist --some --arg",
+                        fail_on_error: false
+                    assert_equal 1, cmd.exit_status
+                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                        cmd.stderr
+                end
             end
         end
     end
 end
 
-
+#module Autoproj
+#    module CLI
+#        describe Exec do
+#            before do
+#                ws_create
+#                @cli = Exec.new(ws)
+#                flexmock(@cli).should_receive(:initialize_and_load)
+#            end
+#
+#            it "passes the full environment, program and the arguments to the exec'd process" do
+#                flexmock(ws).should_receive(:which).with("path").
+#                    and_return('/resolved/path')
+#                env = flexmock
+#                flexmock(ws).should_receive(:full_env => flexmock(resolved_env: env))
+#                flexmock(Process).should_receive(:exec).with(env, "/resolved/path", 'args').once
+#                @cli.run('path', 'args')
+#            end
+#
+#            it "re-raises any exception raised by Process as a CLIInvalidArguments" do
+#                flexmock(ws).should_receive(:which).with("path").
+#                    and_return('/resolved/path')
+#                flexmock(Process).should_receive(:exec).
+#                    and_raise(RuntimeError.new("ENOENT"))
+#                e = assert_raises(CLIInvalidArguments) do
+#                    @cli.run('path')
+#                end
+#                assert_equal "ENOENT", e.message
+#            end
+#
+#            it "re-raises a ExecutableNotFound originally raised by Workspace#which" do
+#                flexmock(ws).should_receive(:which).with("path").
+#                    and_raise(Workspace::ExecutableNotFound.new("cannot find"))
+#                e = assert_raises(CLIInvalidArguments) do
+#                    @cli.run('path')
+#                end
+#                assert_equal "cannot find", e.message
+#            end
+#        end
+#    end
+#end
+#
+#
+#

--- a/test/cli/test_which.rb
+++ b/test/cli/test_which.rb
@@ -1,31 +1,62 @@
 require 'autoproj/test'
+require 'autoproj/aruba_minitest'
 require 'autoproj/cli/which'
 
 module Autoproj
     module CLI
         describe Which do
+            include Autoproj::ArubaMinitest
             before do
-                ws_create
-                @cli = Which.new(ws)
-                flexmock(@cli).should_receive(:initialize_and_load)
+                ws_create(expand_path('.'))
+                set_environment_variable 'AUTOPROJ_CURRENT_ROOT', ws.root_dir
+                @autoproj_bin = File.expand_path(File.join("..", "..", "bin", "autoproj"), __dir__)
             end
 
-            it "displays the value returned by Workspace#which" do
-                flexmock(ws).should_receive(:which).with("path").
-                    and_return('/resolved/path')
-                out, err = capture_io do
-                    @cli.run('path')
+            describe "without using the cache" do
+                it "resolves an executable that can be found in autoproj's PATH" do
+                    write_file 'subdir/test', ''
+                    chmod 0755, 'subdir/test'
+                    append_to_file 'autoproj/init.rb',
+                        "Autoproj.env.add_path 'PATH', '#{expand_path('subdir')}'"
+
+                    cmd = run_command_and_stop "#{@autoproj_bin} which test"
+                    assert_equal expand_path('subdir/test'), cmd.stdout.chomp
                 end
-                assert_equal "/resolved/path\n", out
+
+                it "raises if the executable cannot be resolved" do
+                    cmd = run_command_and_stop "#{@autoproj_bin} which does_not_exist", fail_on_error: false
+                    assert_equal 1, cmd.exit_status
+                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                end
             end
 
-            it "re-raises an ExecutableNotFound exception raied by Workspace#which as CLIInvalidArguments" do
-                flexmock(ws).should_receive(:which).with("path").
-                    and_raise(Workspace::ExecutableNotFound.new("cannot find"))
-                e = assert_raises(CLIInvalidArguments) do
-                    @cli.run('path')
+            describe "using the cache" do
+                it "uses the cache to resolve the executable" do
+                    path = expand_path('subdir').split(File::PATH_SEPARATOR)
+                    cache = Hash[
+                        'set' => Hash['PATH' => path],
+                        'unset' => Array.new,
+                        'update' => Array.new
+                    ]
+                    write_file '.autoproj/env.yml', YAML.dump(cache)
+
+                    write_file 'subdir/test', ''
+                    chmod 0755, 'subdir/test'
+                    cmd = run_command_and_stop "#{@autoproj_bin} which --use-cache test"
+                    assert_equal expand_path('subdir/test'), cmd.stdout.chomp
                 end
-                assert_equal "cannot find", e.message
+                it "produces an error if the executable cannot be found" do
+                    path = expand_path('subdir').split(File::PATH_SEPARATOR)
+                    cache = Hash[
+                        'set' => Hash['PATH' => path],
+                        'unset' => Array.new,
+                        'update' => Array.new
+                    ]
+                    write_file '.autoproj/env.yml', YAML.dump(cache)
+                    cmd = run_command_and_stop "#{@autoproj_bin} which --use-cache does_not_exist", fail_on_error: false
+                    assert_equal 1, cmd.exit_status
+                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                end
             end
         end
     end

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -228,6 +228,8 @@ module Autoproj
                 @pkg0         = ws_add_package_to_layout :cmake, :pkg0
                 @pkg1         = ws_define_package :cmake, :pkg1
                 flexmock(ws.env).should_receive(:dup).once.and_return(@env = flexmock)
+                @env.should_receive(:exported_environment).and_return(
+                    Autobuild::Environment::ExportedEnvironment.new(Hash.new, Array.new, Hash.new))
             end
             it "aggregates the environment of all the selected packages" do
                 flexmock(pkg0.autobuild).should_receive(:apply_env).with(env).once.globally.ordered
@@ -353,7 +355,7 @@ module Autoproj
 
                 it "raises if the file does not exist" do
                     path = target_test_path
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which(path)
                     end
                     assert_equal "given command `#{path}` does not exist, an executable file was expected",
@@ -362,7 +364,7 @@ module Autoproj
 
                 it "raises if the file exists but does not point to an executable file" do
                     path = create_test_file
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which(path)
                     end
                     assert_equal "given command `#{path}` exists but is not an executable file",
@@ -371,7 +373,7 @@ module Autoproj
 
                 it "raises if the path does not point to a file" do
                     path = create_test_directory
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which(path)
                     end
                     assert_equal "given command `#{path}` exists but is not an executable file",
@@ -391,7 +393,7 @@ module Autoproj
 
                 it "raises if the file exists but is not executable" do
                     path = create_test_file
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which('autoproj_which_test')
                     end
                     assert_equal "`autoproj_which_test` resolves to #{path} which is not executable",
@@ -400,7 +402,7 @@ module Autoproj
 
                 it "raises if the file exists but is not a file" do
                     path = create_test_directory
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which('autoproj_which_test')
                     end
                     assert_equal "cannot resolve `autoproj_which_test` to an executable in the workspace",
@@ -408,7 +410,7 @@ module Autoproj
                 end
 
                 it "raises if the file does not exist" do
-                    e = assert_raises(Workspace::ExecutableNotFound) do
+                    e = assert_raises(ExecutableNotFound) do
                         ws.which('autoproj_which_test')
                     end
                     assert_equal "cannot resolve `autoproj_which_test` to an executable in the workspace",


### PR DESCRIPTION
Moreover, we load as little files as possible to reduce the amount
of time loading to a minimum.

Best used with `watch` (https://github.com/rock-core/autoproj/pull/170)

Depends on:
- [x] https://github.com/rock-core/autobuild/pull/43