### PR TITLE
fix configuration not being dirtied on modification to utilities

### DIFF
--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
     s.add_runtime_dependency "bundler"
     s.add_runtime_dependency "autobuild", ">= 1.12.0"
+    s.add_runtime_dependency "backports", '~> 3.0'
     s.add_runtime_dependency "utilrb", '~> 3.0.0', ">= 3.0.0"
     s.add_runtime_dependency "thor", '~> 0.20.0'
     s.add_runtime_dependency 'concurrent-ruby', '~> 1.0.0', '>= 1.0.0'

--- a/lib/autoproj.rb
+++ b/lib/autoproj.rb
@@ -3,6 +3,13 @@ require "enumerator"
 require 'utilrb/module/attr_predicate'
 require 'pathname'
 require 'concurrent'
+
+require 'backports/2.4.0/float/dup'
+require 'backports/2.4.0/fixnum/dup'
+require 'backports/2.4.0/nil_class/dup'
+require 'backports/2.4.0/false_class/dup'
+require 'backports/2.4.0/true_class/dup'
+
 require 'autobuild'
 require 'autoproj/autobuild'
 require 'autoproj/base'

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -1,3 +1,9 @@
+require 'backports/2.4.0/float/dup'
+require 'backports/2.4.0/fixnum/dup'
+require 'backports/2.4.0/nil_class/dup'
+require 'backports/2.4.0/false_class/dup'
+require 'backports/2.4.0/true_class/dup'
+
 module Autoproj
     # Class that does the handling of configuration options as well as
     # loading/saving on disk
@@ -62,7 +68,7 @@ module Autoproj
             else
                 @modified = true
             end
-            config[key] = [value, user_validated]
+            config[key] = [value.dup, user_validated]
         end
 
         # Override a known option value
@@ -92,7 +98,7 @@ module Autoproj
         # Get the value for a given option
         def get(key, *default_value)
             if overrides.has_key?(key)
-                return overrides[key]
+                return overrides[key].dup
             end
 
             has_value = config.has_key?(key)
@@ -100,11 +106,11 @@ module Autoproj
 
             if !declared?(key)
                 if has_value
-                    return value
+                    return value.dup
                 elsif default_value.empty?
                     raise ConfigError, "undeclared option '#{key}'"
                 else
-                    default_value.first
+                    default_value.first.dup
                 end
             else
                 if validated
@@ -113,9 +119,9 @@ module Autoproj
                         doc = "#{doc}:"
                     end
                     displayed_options[key] = value
-                    value
+                    value.dup
                 else
-                    configure(key)
+                    configure(key).dup
                 end
             end
         end
@@ -461,7 +467,7 @@ module Autoproj
         # @param [String] packages the package names
         # @return [void]
         def utility_enable(utility, *packages)
-            utility_config = get(utility_key(utility), Hash.new).dup
+            utility_config = get(utility_key(utility), Hash.new)
             packages.each do |pkg_name|
                 utility_config[pkg_name] = true
             end
@@ -490,7 +496,7 @@ module Autoproj
         # @param [String] packages the package names
         # @return [void]
         def utility_disable(utility, *packages)
-            utility_config = get(utility_key(utility), Hash.new).dup
+            utility_config = get(utility_key(utility), Hash.new)
             packages.each do |pkg_name|
                 utility_config[pkg_name] = false
             end

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -461,7 +461,7 @@ module Autoproj
         # @param [String] packages the package names
         # @return [void]
         def utility_enable(utility, *packages)
-            utility_config = get(utility_key(utility), Hash.new)
+            utility_config = get(utility_key(utility), Hash.new).dup
             packages.each do |pkg_name|
                 utility_config[pkg_name] = true
             end
@@ -490,7 +490,7 @@ module Autoproj
         # @param [String] packages the package names
         # @return [void]
         def utility_disable(utility, *packages)
-            utility_config = get(utility_key(utility), Hash.new)
+            utility_config = get(utility_key(utility), Hash.new).dup
             packages.each do |pkg_name|
                 utility_config[pkg_name] = false
             end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -145,12 +145,21 @@ module Autoproj
 
         describe "#get" do
             describe "undeclared options" do
-                it "returns the set value" do
+                it "returns a copy of set value" do
                     @config.set 'test', 'value'
                     assert_equal 'value', @config.get('test')
                 end
+                it "dups the value before returning it" do
+                    @config.set 'test', 'value'
+                    old = @config.get('test')
+                    refute_same old, @config.get('test')
+                end
                 it "returns the default if one is given" do
                     assert_equal 'value', @config.get('test', 'value')
+                end
+                it "dups the default value before returning it" do
+                    default = 'value'
+                    refute_same default, @config.get('test', default)
                 end
                 it "raises if it is unset and no default is given" do
                     e = assert_raises(Autoproj::ConfigError) do
@@ -168,14 +177,30 @@ module Autoproj
                     @config.should_receive(:configure).with('test').and_return('value')
                     assert_equal 'value', @config.get('test')
                 end
+                it "dups the configured value before returning it" do
+                    value = 'value'
+                    @config.should_receive(:configure).with('test').and_return(value)
+                    refute_same value, @config.get('test')
+                end
                 it "configures it if it is set but unvalidated" do
                     @config.set 'test', 'value'
                     @config.should_receive(:configure).with('test').and_return('value')
                     assert_equal 'value', @config.get('test')
                 end
+                it "dups the unvalidated value before returning it" do
+                    @config.set 'test', 'value'
+                    value = 'value'
+                    @config.should_receive(:configure).with('test').and_return(value)
+                    refute_same value, @config.get('test')
+                end
                 it "returns it if it is set and validated" do
                     @config.set 'test', 'value', true
                     assert_equal 'value', @config.get('test')
+                end
+                it "dups the validated value before returning it" do
+                    value = 'value'
+                    @config.set 'test', value, true
+                    refute_same value, @config.get('test')
                 end
             end
         end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -211,6 +211,100 @@ module Autoproj
                 refute @config.modified?
             end
         end
+
+        describe "#utility_enable" do
+            before do
+                @config.utility_enable 'test', 'my/package'
+            end
+            it "enables the utility for the given packages" do
+                assert @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "dirties the configuration if the utility was not enabled already" do
+                assert @config.modified?
+            end
+            it "does not dirties the configuration if the utility was already enabled" do
+                @config.reset_modified
+                @config.utility_enable 'test', 'my/package'
+                refute @config.modified?
+            end
+        end
+
+        describe "#utility_enable_all" do
+            it "enables the utility for all packages" do
+                @config.utility_enable_all('test')
+                assert @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "dirties the configuration if it was globally disabled" do
+                @config.utility_enable_all('test')
+                assert @config.modified?
+            end
+            it "dirties the configuration if some packages had specific settings" do
+                @config.utility_enable('test', 'my/package')
+                @config.reset_modified
+                @config.utility_enable_all('test')
+                assert @config.modified?
+            end
+            it "allows disabling per-package" do
+                @config.utility_enable_all('test')
+                @config.utility_disable 'test', 'my/package'
+                refute @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "does not dirties the configuration if the utility was already globally enabled" do
+                @config.utility_enable_all('test')
+                @config.reset_modified
+                @config.utility_enable_all('test')
+                refute @config.modified?
+            end
+        end
+
+        describe "#utility_disable" do
+            before do
+                @config.utility_enable('test', 'my/package')
+                @config.reset_modified
+                @config.utility_disable 'test', 'my/package'
+            end
+            it "disables the utility for the given packages" do
+                refute @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "dirties the configuration if the utility was enabled" do
+                assert @config.modified?
+            end
+            it "does not dirties the configuration if the utility was already disabled" do
+                @config.reset_modified
+                @config.utility_disable 'test', 'my/package'
+                refute @config.modified?
+            end
+        end
+
+        describe "#utility_disable_all" do
+            it "disables the utility for all packages" do
+                @config.utility_disable_all('test')
+                refute @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "dirties the configuration if it was globally enabled" do
+                @config.utility_enable_all('test')
+                @config.reset_modified
+                @config.utility_disable_all('test')
+                assert @config.modified?
+            end
+            it "dirties the configuration if some packages had specific settings" do
+                @config.utility_enable('test', 'my/package')
+                @config.reset_modified
+                @config.utility_disable_all('test')
+                assert @config.modified?
+            end
+            it "allows enabling per-package" do
+                @config.utility_disable_all('test')
+                @config.utility_enable 'test', 'my/package'
+                assert @config.utility_enabled_for?('test', 'my/package')
+            end
+            it "does not dirty the configuration if the utility was already globally disabled" do
+                @config.utility_disable_all('test')
+                @config.reset_modified
+                @config.utility_disable_all('test')
+                refute @config.modified?
+            end
+        end
     end
 end
 


### PR DESCRIPTION
The symptom was that `autoproj test enable ...` or
`autoproj test disable ...` would basically do nothing.