### PR TITLE
cli: make 'watch' robust to errors in the configuration

### DIFF
--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -85,6 +85,8 @@ module Autoproj
             end
 
             desc 'watch', 'watch workspace for changes', hide: true
+            option :show_events, type: :boolean, default: false,
+                desc: "whether detected events should be displayed"
             def watch
                 run_autoproj_cli(:watch, :Watch, Hash[])
             end

--- a/test/cli/test_watch.rb
+++ b/test/cli/test_watch.rb
@@ -16,7 +16,7 @@ module Autoproj
             describe "#update_workspace" do
                 it "loads the workspace and updates env.sh" do
                     cli.should_receive(:initialize_and_load).once.ordered
-                    cli.should_receive(:finalize_setup).once.ordered
+                    cli.should_receive(:finalize_setup).once.ordered.and_return([[], nil])
                     cli.should_receive(:export_env_sh).once.ordered
 
                     cli.update_workspace
@@ -125,7 +125,7 @@ module Autoproj
                         process_events
                     end
                     it "triggers the callback when the file is modified" do
-                        cli.should_receive(:callback).once
+                        cli.should_receive(:callback).at_least.once
                         open(manifest_file, 'a') do |file|
                             file << "\n"
                         end


### PR DESCRIPTION
First of all, this changes the way notifiers are set up, to watch
everything in .autoproj/remotes and autoproj/. I don't see the
point in selecting files, which probably guarantees that we're
fatally going to forget one. Moreover, the scheme we had
was failing on boostrap, as the package sets are not present
at this point (and we were not trying to find them).

Then, in case updating the workspace fails, we try to instead
discover the active packages using the installation manifest.
If this fails, we just assume that the configuration will have to
be fixed by the user first.