### PR TITLE
allow a source_dir configuration in the workspace

### DIFF
--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -381,6 +381,18 @@ module Autoproj
             get('build', 'build')
         end
 
+        # Defines a folder to which source packages will be layed out relative to
+        #
+        # If nil, packages will be layed out relative to root_dir
+        # Only relative paths are allowed
+        #
+        # The default is nil
+        #
+        # @return [String,nil]
+        def source_dir
+            get('source', nil)
+        end
+
         # Returns true if there should be one prefix per package
         #
         # The default is false (disabled)

--- a/lib/autoproj/ops/configuration.rb
+++ b/lib/autoproj/ops/configuration.rb
@@ -510,7 +510,7 @@ module Autoproj
             explicit.each do |pkg_or_set, layout_level|
                 next if manifest.find_autobuild_package(pkg_or_set)
                 next if manifest.has_package_set?(pkg_or_set)
-                full_path = File.expand_path(File.join(ws.root_dir, layout_level, pkg_or_set))
+                full_path = File.expand_path(File.join(ws.source_dir, layout_level, pkg_or_set))
                 next if !File.directory?(full_path)
 
                 if handler = auto_add_package(pkg_or_set, full_path)

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -228,6 +228,11 @@ module Autoproj
                     manifest.vcs = VCSDefinition.from_raw(
                         type: 'local', url: config_dir)
                 end
+
+                if config.source_dir && Pathname.new(config.source_dir).absolute?
+                    raise ConfigError, 'source dir path configuration must be relative'
+                end
+
                 os_package_resolver.prefer_indep_over_os_packages = config.prefer_indep_over_os_packages?
                 os_package_resolver.operating_system ||= config.get('operating_system', nil)
             end

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -191,6 +191,20 @@ module Autoproj
             config.set 'build', path, true
         end
 
+        # (see Configuration#source_dir)
+        def source_dir
+            if config.source_dir
+                File.expand_path(config.source_dir, root_dir)
+            else
+                root_dir
+            end
+        end
+
+        # Change {#source_dir}
+        def source_dir=(path)
+            config.set 'source', path, true
+        end
+
         def log_dir
             File.join(prefix_dir, 'log')
         end

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -306,7 +306,7 @@ module Autoproj
                 io.puts "workspace: \"#{root_dir}\""
             end
 
-            Autobuild.srcdir = root_dir
+            Autobuild.srcdir = source_dir
             Autobuild.logdir = log_dir
             if cache_dir = config.importer_cache_dir
                 Autobuild::Importer.default_cache_dirs = cache_dir
@@ -552,7 +552,7 @@ module Autoproj
                 end
 
             pkg = manifest.find_autobuild_package(pkg_name)
-            pkg.srcdir = File.join(root_dir, srcdir)
+            pkg.srcdir = File.join(source_dir, srcdir)
             if pkg.respond_to?(:builddir)
                 pkg.builddir = compute_builddir(pkg)
             end

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -473,6 +473,23 @@ module Autoproj
                 ws.source_dir = 'src'
             end
         end
+
+        describe "#load_config" do
+            attr_reader :ws
+            before do
+                @ws = ws_create
+                FileUtils.mkdir_p File.join(ws.root_dir, '.autoproj')
+                FileUtils.touch File.join(ws.root_dir, '.autoproj', 'config.yml')
+            end
+
+            it "raises if config.source_dir is not relative" do
+                flexmock(Autoproj::Configuration).new_instances.
+                    should_receive(:source_dir).and_return(ws.root_dir)
+                assert_raises(ConfigError) do
+                    ws.load_config
+                end
+            end
+        end
     end
 end
 

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -448,6 +448,31 @@ module Autoproj
                 end
             end
         end
+
+        describe "#source_dir" do
+            attr_reader :ws
+            before do
+                @ws = ws_create
+            end
+
+            it "returns root_dir if 'source' config option is unset" do
+                flexmock(ws.config).should_receive(:source_dir).
+                    and_return(nil)
+                assert_equal ws.source_dir, ws.root_dir
+            end
+
+            it "returns root_dir/source if 'source' config option is set" do
+                flexmock(ws.config).should_receive(:source_dir).
+                    and_return('src')
+                assert_equal ws.source_dir, File.join(ws.root_dir, 'src')
+            end
+
+            it "sets 'source' config option" do
+                flexmock(ws.config).should_receive(:set).
+                    with('source', 'src', true).once
+                ws.source_dir = 'src'
+            end
+        end
     end
 end
 


### PR DESCRIPTION
The layout will be relative to `Autoproj.workspace.source_dir` rather than `Autoproj.workspace.root_dir` . If `Autoproj.workspace.config.source_dir` is unset then `source_dir == root_dir` (which is the default)