### PR TITLE
fix tests after the change in autobuild from \r to ANSI codes to clear lines

### DIFF
--- a/test/cli/test_base.rb
+++ b/test/cli/test_base.rb
@@ -47,7 +47,7 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             base.resolve_user_selection([]) 
                         end
-                        assert_equal ["selected packages: pkg0, pkg1", ""], [out.strip, err.strip]
+                        assert_equal ["#{Autobuild.clear_line}selected packages: pkg0, pkg1", ""], [out.strip, err.strip]
                     end
                 end
 
@@ -79,7 +79,7 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             base.resolve_user_selection(['pkg0']) 
                         end
-                        assert_equal ["selected packages: pkg0", ""], [out.strip, err.strip]
+                        assert_equal ["#{Autobuild.clear_line}selected packages: pkg0", ""], [out.strip, err.strip]
                     end
                 end
 
@@ -108,7 +108,8 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             selection, _ = base.resolve_user_selection([package_relative_path]) 
                         end
-                        assert_equal "auto-adding #{package_path} using the cmake package handler", out.strip
+                        assert_equal "#{Autobuild.clear_line}  auto-adding #{package_path}"\
+                            " using the cmake package handler", out.strip
                         assert_equal "", err
                         assert_equal ['path/to/package'], selection.each_source_package_name.to_a
                         autobuild_package = ws.manifest.find_autobuild_package('path/to/package')

--- a/test/cli/test_exec.rb
+++ b/test/cli/test_exec.rb
@@ -39,7 +39,7 @@ ENV SOME_VALUE
                     cmd = run_command_and_stop "#{@autoproj_bin} exec does_not_exist --some --arg",
                         fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
                         cmd.stderr
                 end
             end
@@ -67,7 +67,7 @@ ENV SOME_VALUE
                     cmd = run_command_and_stop "#{@autoproj_bin} exec --use-cache does_not_exist --some --arg",
                         fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
                         cmd.stderr
                 end
             end

--- a/test/cli/test_which.rb
+++ b/test/cli/test_which.rb
@@ -26,7 +26,7 @@ module Autoproj
                 it "raises if the executable cannot be resolved" do
                     cmd = run_command_and_stop "#{@autoproj_bin} which does_not_exist", fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
                 end
             end
 
@@ -55,7 +55,7 @@ module Autoproj
                     write_file '.autoproj/env.yml', YAML.dump(cache)
                     cmd = run_command_and_stop "#{@autoproj_bin} which --use-cache does_not_exist", fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "\r  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
                 end
             end
         end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/rock-core/autobuild/pull/53