### PR TITLE
Global workspace registration

### DIFF
--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'tty-prompt', '~> 0.15.0'
     s.add_runtime_dependency 'tty-spinner', '~> 0.8.0'
     s.add_runtime_dependency 'rb-inotify' if RbConfig::CONFIG['target_os'] =~ /linux/
+    s.add_runtime_dependency 'xdg'
     s.add_development_dependency "flexmock", '~> 2.0', ">= 2.0.0"
     s.add_development_dependency "minitest", "~> 5.0", ">= 5.0"
     s.add_development_dependency "simplecov"

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -62,8 +62,16 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
+                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
                 default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path     = default_gem_path
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             def env_for_child

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -62,16 +62,7 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
-                default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+                install_gems_in_gem_user_dir
             end
 
             def env_for_child
@@ -167,7 +158,18 @@ module Autoproj
             end
             # Install autoproj in Gem's default user dir
             def install_gems_in_gem_user_dir
-                @gems_install_path = File.join(Gem.user_home, '.gem')
+                xdg_default_gem_path = File.join(
+                    Dir.home, '.local', 'share', 'autoproj', 'gems')
+                default_gem_path = File.join(
+                    Dir.home, '.autoproj', 'gems')
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             # Whether autoproj should prefer OS-independent packages over their

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -62,16 +62,7 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
-                default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+                install_gems_in_gem_user_dir
             end
 
             def env_for_child
@@ -150,7 +141,7 @@ module Autoproj
             #
             # They are installed in a versioned subdirectory of this path, e.g.
             # {#gem_path_suffix}.
-            # 
+            #
             # @return [String]
             attr_reader :gems_install_path
             # The GEM_HOME under which the workspace's gems should be installed
@@ -167,7 +158,18 @@ module Autoproj
             end
             # Install autoproj in Gem's default user dir
             def install_gems_in_gem_user_dir
-                @gems_install_path = File.join(Gem.user_home, '.gem')
+                xdg_default_gem_path = File.join(
+                    Dir.home, '.local', 'share', 'autoproj', 'gems')
+                default_gem_path = File.join(
+                    Dir.home, '.autoproj', 'gems')
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             # Whether autoproj should prefer OS-independent packages over their

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -62,8 +62,16 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
+                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
                 default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path     = default_gem_path
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             def env_for_child

--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -2,6 +2,7 @@ require 'thor'
 require 'tty/color'
 require 'autoproj/cli/main_test'
 require 'autoproj/cli/main_plugin'
+require 'autoproj/cli/main_global'
 require 'autoproj/reporter'
 
 module Autoproj
@@ -466,6 +467,9 @@ The format is a string in which special values can be expanded using a $VARNAME 
             desc 'plugin', 'interface to manage autoproj plugins'
             subcommand 'plugin', MainPlugin
 
+            desc 'global', 'global management of the known workspaces'
+            subcommand 'global', MainGlobal
+
             desc 'patch', 'applies patches necessary for the selected package',
                 hide: true
             def patch(*packages)
@@ -518,3 +522,4 @@ The format is a string in which special values can be expanded using a $VARNAME 
         end
     end
 end
+

--- a/lib/autoproj/cli/main_global.rb
+++ b/lib/autoproj/cli/main_global.rb
@@ -1,0 +1,39 @@
+module Autoproj
+    module CLI
+        class MainGlobal < Thor
+            namespace 'global'
+
+            desc 'register', 'register the current workspace'
+            def register
+                require 'autoproj'
+                ws = Workspace.default
+                ws.load_config
+                ws.register_workspace
+            end
+
+            desc 'status', 'display information about the known workspaces'
+            def status
+                require 'autoproj'
+                ws = Workspace.registered_workspaces
+                fields = Workspace::RegisteredWorkspace.members.map(&:to_s)
+                format_w = fields.map(&:length).max + 1
+                format = "%-#{format_w}s %s (%s)"
+                blocks = ws.map do |w|
+                    %w[root_dir prefix_dir build_dir].map do |name|
+                        dir = w.public_send(name)
+                        if dir.start_with?('/')
+                            status = if File.directory?(dir)
+                                         Autobuild.color('present', :green)
+                                     else
+                                         Autobuild.color('absent', :yellow)
+                                     end
+
+                            format(format, "#{name}:", dir, status)
+                        end
+                    end.compact.join("\n")
+                end
+                puts blocks.join("---\n")
+            end
+        end
+    end
+end

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -52,16 +52,7 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
-                default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+                install_gems_in_gem_user_dir
             end
 
             def env_for_child
@@ -140,11 +131,11 @@ module Autoproj
             #
             # They are installed in a versioned subdirectory of this path, e.g.
             # {#gem_path_suffix}.
-            # 
+            #
             # @return [String]
             attr_reader :gems_install_path
             # The GEM_HOME under which the workspace's gems should be installed
-            # 
+            #
             # @return [String]
             def gems_gem_home; File.join(gems_install_path, gem_path_suffix) end
             # Sets where the workspace's gems should be installed
@@ -157,7 +148,18 @@ module Autoproj
             end
             # Install autoproj in Gem's default user dir
             def install_gems_in_gem_user_dir
-                @gems_install_path = File.join(Gem.user_home, '.gem')
+                xdg_default_gem_path = File.join(
+                    Dir.home, '.local', 'share', 'autoproj', 'gems')
+                default_gem_path = File.join(
+                    Dir.home, '.autoproj', 'gems')
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             # Whether autoproj should prefer OS-independent packages over their
@@ -173,7 +175,7 @@ module Autoproj
 
                 candidates = ['gem']
                 if ruby_bin =~ /^ruby(.+)$/
-                    candidates.unshift "gem#{$1}" 
+                    candidates.unshift "gem#{$1}"
                 end
 
                 candidates.each do |gem_name|
@@ -368,7 +370,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
 
 load Gem.bin_path('bundler', 'bundler')"
             end
-            
+
             def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
 "#! #{ruby_executable}
 
@@ -511,7 +513,7 @@ require 'bundler/setup'
 
             def load_config
                 v1_config_path = File.join(root_dir, 'autoproj', 'config.yml')
-                
+
                 config = Hash.new
                 if File.file?(v1_config_path)
                     config.merge!(YAML.load(File.read(v1_config_path)) || Hash.new)
@@ -598,4 +600,3 @@ require 'bundler/setup'
         end
     end
 end
-

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -52,8 +52,16 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
+                xdg_default_gem_path = File.join(Dir.home, '.local', 'share', 'autoproj', 'gems')
                 default_gem_path = File.join(Dir.home, '.autoproj', 'gems')
-                @gems_install_path     = default_gem_path
+                @gems_install_path =
+                    if File.directory?(xdg_default_gem_path)
+                        xdg_default_gem_path
+                    elsif File.directory?(default_gem_path)
+                        default_gem_path
+                    else
+                        xdg_default_gem_path
+                    end
             end
 
             def env_for_child


### PR DESCRIPTION
Depends on:
- [ ] #201 

This commit is inspired by vagrant's global-status command, which allows to have an overview
of the vagrant environments currently active in any given system. This PR introduces the `global`
subcommand, and in particular `global status`, which tells which workspaces are available and where
they are.

This is really for bookkeeping. It for instance allows to find out that some build/prefix directories
from old workspaces are still there.