### PR TITLE
tests: fix cli-related tests (now uses tty-cursor gem)

### DIFF
--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "minitest", "~> 5.0", ">= 5.0"
     s.add_development_dependency "simplecov"
     s.add_development_dependency "aruba"
+    s.add_development_dependency "tty-cursor"
 end
 

--- a/test/cli/test_base.rb
+++ b/test/cli/test_base.rb
@@ -1,10 +1,12 @@
 require 'autoproj/test'
 require 'autoproj/cli/base'
+require 'tty-cursor'
 module Autoproj
     module CLI
         describe Base do
             attr_reader :ws, :base
             before do
+                @cursor = TTY::Cursor
                 @ws = ws_create
                 @base = Base.new(ws)
             end
@@ -47,7 +49,8 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             base.resolve_user_selection([]) 
                         end
-                        assert_equal ["#{Autobuild.clear_line}selected packages: pkg0, pkg1", ""], [out.strip, err.strip]
+                        assert_equal ["#{@cursor.column(1)}#{@cursor.clear_screen_down}selected packages: pkg0, pkg1\n#{@cursor.clear_screen_down}#{@cursor.column(0)}",
+                                      ""], [out.strip, err.strip]
                     end
                 end
 
@@ -79,7 +82,8 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             base.resolve_user_selection(['pkg0']) 
                         end
-                        assert_equal ["#{Autobuild.clear_line}selected packages: pkg0", ""], [out.strip, err.strip]
+                        assert_equal ["#{@cursor.column(1)}#{@cursor.clear_screen_down}selected packages: pkg0\n#{@cursor.clear_screen_down}#{@cursor.column(0)}",
+                                      ""], [out.strip, err.strip]
                     end
                 end
 
@@ -108,8 +112,8 @@ module Autoproj
                         out, err = capture_subprocess_io do
                             selection, _ = base.resolve_user_selection([package_relative_path]) 
                         end
-                        assert_equal "#{Autobuild.clear_line}  auto-adding #{package_path}"\
-                            " using the cmake package handler", out.strip
+                        assert_equal "#{@cursor.column(1)}#{@cursor.clear_screen_down}  auto-adding #{package_path}"\
+                            " using the cmake package handler\n#{@cursor.clear_screen_down}#{@cursor.column(0)}", out.strip
                         assert_equal "", err
                         assert_equal ['path/to/package'], selection.each_source_package_name.to_a
                         autobuild_package = ws.manifest.find_autobuild_package('path/to/package')

--- a/test/cli/test_exec.rb
+++ b/test/cli/test_exec.rb
@@ -1,12 +1,14 @@
 require 'autoproj/test'
 require 'autoproj/aruba_minitest'
 require 'autoproj/cli/exec'
+require 'tty-cursor'
 
 module Autoproj
     module CLI
         describe Exec do
             include Autoproj::ArubaMinitest
             before do
+                @cursor = TTY::Cursor
                 ws_create(expand_path('.'))
                 set_environment_variable 'AUTOPROJ_CURRENT_ROOT', ws.root_dir
                 @autoproj_bin = File.expand_path(File.join("..", "..", "bin", "autoproj"), __dir__)
@@ -39,7 +41,7 @@ ENV SOME_VALUE
                     cmd = run_command_and_stop "#{@autoproj_bin} exec does_not_exist --some --arg",
                         fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                    assert_equal "#{@cursor.column(1)}#{@cursor.clear_screen_down}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
                         cmd.stderr
                 end
             end
@@ -67,7 +69,7 @@ ENV SOME_VALUE
                     cmd = run_command_and_stop "#{@autoproj_bin} exec --use-cache does_not_exist --some --arg",
                         fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
+                    assert_equal "#{@cursor.column(1)}#{@cursor.clear_screen_down}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n",
                         cmd.stderr
                 end
             end

--- a/test/cli/test_which.rb
+++ b/test/cli/test_which.rb
@@ -1,12 +1,14 @@
 require 'autoproj/test'
 require 'autoproj/aruba_minitest'
 require 'autoproj/cli/which'
+require 'tty-cursor'
 
 module Autoproj
     module CLI
         describe Which do
             include Autoproj::ArubaMinitest
             before do
+                @cursor = TTY::Cursor
                 ws_create(expand_path('.'))
                 set_environment_variable 'AUTOPROJ_CURRENT_ROOT', ws.root_dir
                 @autoproj_bin = File.expand_path(File.join("..", "..", "bin", "autoproj"), __dir__)
@@ -26,7 +28,7 @@ module Autoproj
                 it "raises if the executable cannot be resolved" do
                     cmd = run_command_and_stop "#{@autoproj_bin} which does_not_exist", fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                    assert_equal "#{@cursor.column(1)}#{@cursor.clear_screen_down}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
                 end
             end
 
@@ -55,7 +57,7 @@ module Autoproj
                     write_file '.autoproj/env.yml', YAML.dump(cache)
                     cmd = run_command_and_stop "#{@autoproj_bin} which --use-cache does_not_exist", fail_on_error: false
                     assert_equal 1, cmd.exit_status
-                    assert_equal "#{Autobuild.clear_line}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
+                    assert_equal "#{@cursor.column(1)}#{@cursor.clear_screen_down}  ERROR: cannot resolve `does_not_exist` to an executable in the workspace\n", cmd.stderr
                 end
             end
         end


### PR DESCRIPTION
These tests were broken since rock-core/autobuild#54