### PR TITLE
Post phase hooks

### DIFF
--- a/bin/alocate
+++ b/bin/alocate
@@ -1,7 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'autoproj/cli/main'
-Autoproj::CLI.basic_setup
+argv = Autoproj::CLI.basic_setup
 
 class Alocate < Autoproj::CLI::Main
     def self.banner(*)
@@ -10,13 +10,11 @@ class Alocate < Autoproj::CLI::Main
 end
 
 begin
-    if ARGV.include?('--help') || ARGV.include?('help')
+    if argv.include?('--help') || argv.include?('help')
         Alocate.start(['help', 'locate'])
     else
-        Alocate.start(['locate', *ARGV])
+        Alocate.start(['locate', *argv])
     end
 rescue Interrupt
     # Already notified in the reporting infrastructure
 end
-
-

--- a/bin/alog
+++ b/bin/alog
@@ -3,7 +3,8 @@
 require 'autoproj/cli/main'
 require 'autoproj/cli/locate'
 
-if ARGV.include?('--help') || ARGV.include?('help')
+argv = Autoproj::CLI.basic_setup
+if argv.include?('--help') || argv.include?('help')
     puts "Usage:"
     puts "  alog [package]"
     puts
@@ -11,11 +12,10 @@ if ARGV.include?('--help') || ARGV.include?('help')
     exit 0
 end
 
-Autoproj::CLI.basic_setup
 Autoproj.report(silent: true) do
     cli = Autoproj::CLI::Locate.new
 
-    arg = ARGV.first || Dir.pwd
+    arg = argv.first || Dir.pwd
     if File.directory?(arg)
         arg = "#{File.expand_path(arg)}/"
     end

--- a/bin/amake
+++ b/bin/amake
@@ -1,8 +1,8 @@
 #! /usr/bin/env ruby
 
 require 'autoproj/cli/main'
-Autoproj::CLI.basic_setup
 
+argv = Autoproj::CLI.basic_setup
 class Amake < Autoproj::CLI::Main
     def self.banner(*)
         "amake [options]"
@@ -10,12 +10,11 @@ class Amake < Autoproj::CLI::Main
 end
 
 begin
-    if ARGV.include?('--help') || ARGV.include?('help')
+    if argv.include?('--help') || argv.include?('help')
         Amake.start(['help', 'build'])
     else
-        Amake.start(['build', '--amake', *ARGV])
+        Amake.start(['build', '--amake', *argv])
     end
 rescue Interrupt
     # Already notified in the reporting infrastructure
 end
-

--- a/bin/aup
+++ b/bin/aup
@@ -1,7 +1,8 @@
 #! /usr/bin/env ruby
 
 require 'autoproj/cli/main'
-Autoproj::CLI.basic_setup
+
+argv = Autoproj::CLI.basic_setup
 
 class Aup < Autoproj::CLI::Main
     def self.banner(*)
@@ -10,10 +11,10 @@ class Aup < Autoproj::CLI::Main
 end
 
 begin
-    if ARGV.include?('--help') || ARGV.include?('help')
+    if argv.include?('--help') || argv.include?('help')
         Aup.start(['help', 'update'])
     else
-        Aup.start(['update', *ARGV, '--aup'])
+        Aup.start(['update', *argv, '--aup'])
     end
 rescue Interrupt
     # Already notified in the reporting infrastructure

--- a/bin/autoproj
+++ b/bin/autoproj
@@ -2,15 +2,10 @@
 
 require 'autoproj/cli'
 require 'autoproj/cli/main'
-Autoproj::CLI.basic_setup
+argv = Autoproj::CLI.basic_setup
 
-argv = ARGV.find_all { |arg| arg != "--no-plugins" }
-if argv.size == ARGV.size
-    Autoproj::CLI.load_plugins
-end
 begin
     Autoproj::CLI::Main.start(argv)
 rescue Interrupt
     # Already notified in the reporting infrastructure
 end
-

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -57,7 +57,10 @@ module Autoproj
 
                 load_config
                 if config['ruby_executable'] != Gem.ruby
-                    raise "this autoproj installation was already bootstrapped using #{config['ruby_executable']}, but you are currently running under #{Gem.ruby}. Changing the ruby interpreter in a given workspace is not supported, you need to do a clean bootstrap"
+                    raise "this autoproj installation was already bootstrapped using "\
+                        "#{config['ruby_executable']}, but you are currently running "\
+                        "under #{Gem.ruby}. Changing the ruby interpreter in a given "\
+                        "workspace is not supported, you need to do a clean bootstrap"
                 end
                 @ruby_executable = config['ruby_executable']
                 @local = false
@@ -141,13 +144,15 @@ module Autoproj
             #
             # They are installed in a versioned subdirectory of this path, e.g.
             # {#gem_path_suffix}.
-            # 
+            #
             # @return [String]
             attr_reader :gems_install_path
             # The GEM_HOME under which the workspace's gems should be installed
-            # 
+            #
             # @return [String]
-            def gems_gem_home; File.join(gems_install_path, gem_path_suffix) end
+            def gems_gem_home
+                File.join(gems_install_path, gem_path_suffix)
+            end
             # Sets where the workspace's gems should be installed
             #
             # @param [String] path the absolute path that should be given to
@@ -184,9 +189,13 @@ module Autoproj
             # Whether autoproj should prefer OS-independent packages over their
             # OS-packaged equivalents (e.g. the thor gem vs. the ruby-thor
             # Debian package)
-            def prefer_indep_over_os_packages?; @prefer_indep_over_os_packages end
+            def prefer_indep_over_os_packages?
+                @prefer_indep_over_os_packages
+            end
             # (see #prefer_index_over_os_packages?)
-            def prefer_indep_over_os_packages=(flag); @prefer_indep_over_os_packages = !!flag end
+            def prefer_indep_over_os_packages=(flag)
+                @prefer_indep_over_os_packages = !!flag
+            end
 
             def self.guess_gem_program
                 ruby_bin = RbConfig::CONFIG['RUBY_INSTALL_NAME']
@@ -194,7 +203,7 @@ module Autoproj
 
                 candidates = ['gem']
                 if ruby_bin =~ /^ruby(.+)$/
-                    candidates.unshift "gem#{$1}" 
+                    candidates.unshift "gem#{$1}"
                 end
 
                 candidates.each do |gem_name|
@@ -202,7 +211,8 @@ module Autoproj
                         return gem_full_path
                     end
                 end
-                raise ArgumentError, "cannot find a gem program (tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
+                raise ArgumentError, "cannot find a gem program "\
+                    "(tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
             end
 
             # The content of the default {#gemfile}
@@ -226,39 +236,48 @@ module Autoproj
                     opt.on '--skip-stage2', 'do not run the stage2 install' do
                         @skip_stage2 = true
                     end
-                    opt.on '--gem-source=URL', String, "use this source for RubyGems instead of rubygems.org" do |url|
+                    opt.on '--gem-source=URL', String, "use this source for RubyGems "\
+                        "instead of rubygems.org" do |url|
                         @gem_source = url
                     end
-                    opt.on '--gems-path=PATH', "install gems under this path instead of ~/.autoproj/gems" do |path|
+                    opt.on '--gems-path=PATH', "install gems under this path instead "\
+                        "of ~/.autoproj/gems" do |path|
                         self.gems_install_path     = path
                     end
                     opt.on '--public-gems', "install gems in the default gem location" do
                         self.install_gems_in_gem_user_dir
                     end
-                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided string as a version constraint for autoproj' do |version|
+                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided "\
+                        "string as a version constraint for autoproj' do |version|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = default_gemfile_contents(version)
                     end
-                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install autoproj instead of the default' do |path|
+                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install "\
+                        "autoproj instead of the default' do |path|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = File.read(path)
                     end
-                    opt.on '--seed-config=PATH', String, 'path to a seed file that should be used to initialize the configuration' do |path|
+                    opt.on '--seed-config=PATH', String, 'path to a seed file that "\
+                        "should be used to initialize the configuration' do |path|
                         @config.merge!(YAML.load(File.read(path)))
                     end
-                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent packages (such as a RubyGem) over their OS-packaged equivalent (e.g. the thor gem vs. the ruby-thor debian package)' do
+                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent "\
+                        "packages (such as a RubyGem) over their OS-packaged equivalent "\
+                        "(e.g. the thor gem vs. the ruby-thor debian package)' do
                         @prefer_indep_over_os_packages = true
                     end
-                    opt.on '--[no-]color', 'do not use colored output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]color', 'do not use colored output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--color"
                         else autoproj_options << '--no-color'
                         end
                     end
-                    opt.on '--[no-]progress', 'do not use progress output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]progress', 'do not use progress output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--progress"
                         else autoproj_options << '--no-progress'
                         end
@@ -291,9 +310,11 @@ module Autoproj
 
                 result = system(
                     env_for_child.merge('GEM_HOME' => gems_gem_home),
-                    Gem.ruby, gem_program, 'install', '--env-shebang', '--no-document', '--no-format-executable', '--clear-sources', '--source', gem_source,
-                        *local,
-                        "--bindir=#{File.join(gems_gem_home, 'bin')}", 'bundler', **redirection)
+                    Gem.ruby, gem_program, 'install',
+                        '--env-shebang', '--no-document', '--no-format-executable',
+                        '--clear-sources', '--source', gem_source,
+                        *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
+                        'bundler', **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
@@ -304,14 +325,15 @@ module Autoproj
                 if File.exist?(bundler_path)
                     bundler_path
                 else
-                    STDERR.puts "gem install bundler returned successfully, but still cannot find bundler in #{bundler_path}"
+                    STDERR.puts "gem install bundler returned successfully, but still "\
+                        "cannot find bundler in #{bundler_path}"
                     nil
                 end
             end
 
             def install_autoproj(bundler)
-                # Force bundler to update. If the user does not want this, let him specify a
-                # Gemfile with tighter version constraints
+                # Force bundler to update. If the user does not want this, let
+                # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, 'Gemfile.lock')
                 if File.exist?(lockfile)
                     FileUtils.rm lockfile
@@ -335,12 +357,14 @@ module Autoproj
                     exit 1
                 end
             ensure
-                self.class.rewrite_shims(shims_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+                self.class.rewrite_shims(shims_path, ruby_executable,
+                    root_dir, autoproj_gemfile_path, gems_gem_home)
             end
 
             EXCLUDED_FROM_SHIMS = %w{rake thor}
 
-            def self.rewrite_shims(shim_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+            def self.rewrite_shims(shim_path, ruby_executable,
+                root_dir, autoproj_gemfile_path, gems_gem_home)
                 FileUtils.mkdir_p shim_path
                 File.open(File.join(shim_path, 'ruby'), 'w') do |io|
                     io.puts "#! /bin/sh"
@@ -363,10 +387,12 @@ module Autoproj
                     bin_script_lines = File.readlines(bin_script)
                     File.open(bin_shim, 'w') do |io|
                         if bin_name == 'bundler' || bin_name == 'bundle'
-                            io.puts shim_bundler(ruby_executable, autoproj_gemfile_path, gems_gem_home)
+                            io.puts shim_bundler(ruby_executable,
+                                autoproj_gemfile_path, gems_gem_home)
                         else
                             load_line = bin_script_lines.grep(/load Gem.bin_path/).first
-                            io.puts shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+                            io.puts shim_script(ruby_executable, root_dir,
+                                autoproj_gemfile_path, gems_gem_home, load_line)
                         end
                     end
                     FileUtils.chmod 0755, bin_shim
@@ -389,8 +415,9 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
 
 load Gem.bin_path('bundler', 'bundler')"
             end
-            
-            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+
+            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path,
+                gems_gem_home, load_line)
 "#! #{ruby_executable}
 
 if defined?(Bundler)
@@ -452,9 +479,10 @@ require 'bundler/setup'
                     "if File.file?(config_path)",
                     "    require 'yaml'",
                     "    config = YAML.load(File.read(config_path)) || Hash.new",
-                    "    (config['plugins'] || Hash.new).each do |plugin_name, (version, options)|",
-                    "        gem plugin_name, version, **options",
-                    "    end",
+                    "    (config['plugins'] || Hash.new).",
+                    "        each do |plugin_name, (version, options)|",
+                    "            gem plugin_name, version, **options",
+                    "        end",
                     "end"
                 ].join("\n")
 
@@ -468,7 +496,8 @@ require 'bundler/setup'
 
 
             def find_in_clean_path(command, *additional_paths)
-                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) + additional_paths
+                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) +
+                    additional_paths
                 clean_path.each do |p|
                     full_path = File.join(p, command)
                     if File.file?(full_path)
@@ -492,7 +521,8 @@ require 'bundler/setup'
                 #
                 # So, we're calling 'gem' as a subcommand to discovery the
                 # actual bindir
-                bindir = IO.popen(env_for_child, [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
+                bindir = IO.popen(env_for_child,
+                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
                 if bindir
                     @gem_bindir = bindir.chomp
                 else
@@ -502,7 +532,9 @@ require 'bundler/setup'
 
             def install
                 if ENV['BUNDLER_GEMFILE']
-                    raise "cannot run autoproj_install or autoproj_bootstrap while under a 'bundler exec' subcommand or having loaded an env.sh. Open a new console and try again"
+                    raise "cannot run autoproj_install or autoproj_bootstrap while "\
+                        "under a 'bundler exec' subcommand or having loaded an env.sh. "\
+                        "Open a new console and try again"
                 end
 
                 gem_program  = self.class.guess_gem_program
@@ -532,7 +564,7 @@ require 'bundler/setup'
 
             def load_config
                 v1_config_path = File.join(root_dir, 'autoproj', 'config.yml')
-                
+
                 config = Hash.new
                 if File.file?(v1_config_path)
                     config.merge!(YAML.load(File.read(v1_config_path)) || Hash.new)
@@ -546,7 +578,10 @@ require 'bundler/setup'
                 ruby_executable = File.join(ruby_bindir, ruby)
                 if current = config['ruby_executable'] # When upgrading or reinstalling
                     if current != ruby_executable
-                        raise "this workspace has already been initialized using #{current}, you cannot run autoproj install with #{ruby_executable}. If you know what you're doing, delete the ruby_executable line in config.yml and try again"
+                        raise "this workspace has already been initialized using "\
+                        "#{current}, you cannot run autoproj install with "\
+                        "#{ruby_executable}. If you know what you're doing, "\
+                        "delete the ruby_executable line in config.yml and try again"
                     end
                 else
                     config['ruby_executable'] = ruby_executable
@@ -605,21 +640,22 @@ require 'bundler/setup'
                 save_env_sh(*vars)
                 puts "running 'autoproj envsh' to generate a proper env.sh"
                 if !system(Gem.ruby, autoproj_path, 'envsh', *autoproj_options)
-                    STDERR.puts "failed to run autoproj envsh on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj envsh on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
                 # This is really needed on an existing install to install the
                 # gems that were present in the v1 layout
                 puts "running 'autoproj osdeps' to re-install missing gems"
                 if !system(Gem.ruby, autoproj_path, 'osdeps')
-                    STDERR.puts "failed to run autoproj osdeps on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj osdeps on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
             end
         end
     end
 end
-
 
 
 ENV.delete('BUNDLE_GEMFILE')

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -57,7 +57,10 @@ module Autoproj
 
                 load_config
                 if config['ruby_executable'] != Gem.ruby
-                    raise "this autoproj installation was already bootstrapped using #{config['ruby_executable']}, but you are currently running under #{Gem.ruby}. Changing the ruby interpreter in a given workspace is not supported, you need to do a clean bootstrap"
+                    raise "this autoproj installation was already bootstrapped using "\
+                        "#{config['ruby_executable']}, but you are currently running "\
+                        "under #{Gem.ruby}. Changing the ruby interpreter in a given "\
+                        "workspace is not supported, you need to do a clean bootstrap"
                 end
                 @ruby_executable = config['ruby_executable']
                 @local = false
@@ -145,9 +148,11 @@ module Autoproj
             # @return [String]
             attr_reader :gems_install_path
             # The GEM_HOME under which the workspace's gems should be installed
-            # 
+            #
             # @return [String]
-            def gems_gem_home; File.join(gems_install_path, gem_path_suffix) end
+            def gems_gem_home
+                File.join(gems_install_path, gem_path_suffix)
+            end
             # Sets where the workspace's gems should be installed
             #
             # @param [String] path the absolute path that should be given to
@@ -184,9 +189,13 @@ module Autoproj
             # Whether autoproj should prefer OS-independent packages over their
             # OS-packaged equivalents (e.g. the thor gem vs. the ruby-thor
             # Debian package)
-            def prefer_indep_over_os_packages?; @prefer_indep_over_os_packages end
+            def prefer_indep_over_os_packages?
+                @prefer_indep_over_os_packages
+            end
             # (see #prefer_index_over_os_packages?)
-            def prefer_indep_over_os_packages=(flag); @prefer_indep_over_os_packages = !!flag end
+            def prefer_indep_over_os_packages=(flag)
+                @prefer_indep_over_os_packages = !!flag
+            end
 
             def self.guess_gem_program
                 ruby_bin = RbConfig::CONFIG['RUBY_INSTALL_NAME']
@@ -194,7 +203,7 @@ module Autoproj
 
                 candidates = ['gem']
                 if ruby_bin =~ /^ruby(.+)$/
-                    candidates.unshift "gem#{$1}" 
+                    candidates.unshift "gem#{$1}"
                 end
 
                 candidates.each do |gem_name|
@@ -202,7 +211,8 @@ module Autoproj
                         return gem_full_path
                     end
                 end
-                raise ArgumentError, "cannot find a gem program (tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
+                raise ArgumentError, "cannot find a gem program "\
+                    "(tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
             end
 
             # The content of the default {#gemfile}
@@ -226,39 +236,48 @@ module Autoproj
                     opt.on '--skip-stage2', 'do not run the stage2 install' do
                         @skip_stage2 = true
                     end
-                    opt.on '--gem-source=URL', String, "use this source for RubyGems instead of rubygems.org" do |url|
+                    opt.on '--gem-source=URL', String, "use this source for RubyGems "\
+                        "instead of rubygems.org" do |url|
                         @gem_source = url
                     end
-                    opt.on '--gems-path=PATH', "install gems under this path instead of ~/.autoproj/gems" do |path|
+                    opt.on '--gems-path=PATH', "install gems under this path instead "\
+                        "of ~/.autoproj/gems" do |path|
                         self.gems_install_path     = path
                     end
                     opt.on '--public-gems', "install gems in the default gem location" do
                         self.install_gems_in_gem_user_dir
                     end
-                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided string as a version constraint for autoproj' do |version|
+                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided "\
+                        "string as a version constraint for autoproj' do |version|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = default_gemfile_contents(version)
                     end
-                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install autoproj instead of the default' do |path|
+                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install "\
+                        "autoproj instead of the default' do |path|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = File.read(path)
                     end
-                    opt.on '--seed-config=PATH', String, 'path to a seed file that should be used to initialize the configuration' do |path|
+                    opt.on '--seed-config=PATH', String, 'path to a seed file that "\
+                        "should be used to initialize the configuration' do |path|
                         @config.merge!(YAML.load(File.read(path)))
                     end
-                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent packages (such as a RubyGem) over their OS-packaged equivalent (e.g. the thor gem vs. the ruby-thor debian package)' do
+                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent "\
+                        "packages (such as a RubyGem) over their OS-packaged equivalent "\
+                        "(e.g. the thor gem vs. the ruby-thor debian package)' do
                         @prefer_indep_over_os_packages = true
                     end
-                    opt.on '--[no-]color', 'do not use colored output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]color', 'do not use colored output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--color"
                         else autoproj_options << '--no-color'
                         end
                     end
-                    opt.on '--[no-]progress', 'do not use progress output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]progress', 'do not use progress output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--progress"
                         else autoproj_options << '--no-progress'
                         end
@@ -291,9 +310,11 @@ module Autoproj
 
                 result = system(
                     env_for_child.merge('GEM_HOME' => gems_gem_home),
-                    Gem.ruby, gem_program, 'install', '--env-shebang', '--no-document', '--no-format-executable', '--clear-sources', '--source', gem_source,
-                        *local,
-                        "--bindir=#{File.join(gems_gem_home, 'bin')}", 'bundler', **redirection)
+                    Gem.ruby, gem_program, 'install',
+                        '--env-shebang', '--no-document', '--no-format-executable',
+                        '--clear-sources', '--source', gem_source,
+                        *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
+                        'bundler', **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
@@ -304,14 +325,15 @@ module Autoproj
                 if File.exist?(bundler_path)
                     bundler_path
                 else
-                    STDERR.puts "gem install bundler returned successfully, but still cannot find bundler in #{bundler_path}"
+                    STDERR.puts "gem install bundler returned successfully, but still "\
+                        "cannot find bundler in #{bundler_path}"
                     nil
                 end
             end
 
             def install_autoproj(bundler)
-                # Force bundler to update. If the user does not want this, let him specify a
-                # Gemfile with tighter version constraints
+                # Force bundler to update. If the user does not want this, let
+                # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, 'Gemfile.lock')
                 if File.exist?(lockfile)
                     FileUtils.rm lockfile
@@ -335,12 +357,14 @@ module Autoproj
                     exit 1
                 end
             ensure
-                self.class.rewrite_shims(shims_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+                self.class.rewrite_shims(shims_path, ruby_executable,
+                    root_dir, autoproj_gemfile_path, gems_gem_home)
             end
 
             EXCLUDED_FROM_SHIMS = %w{rake thor}
 
-            def self.rewrite_shims(shim_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+            def self.rewrite_shims(shim_path, ruby_executable,
+                root_dir, autoproj_gemfile_path, gems_gem_home)
                 FileUtils.mkdir_p shim_path
                 File.open(File.join(shim_path, 'ruby'), 'w') do |io|
                     io.puts "#! /bin/sh"
@@ -363,10 +387,12 @@ module Autoproj
                     bin_script_lines = File.readlines(bin_script)
                     File.open(bin_shim, 'w') do |io|
                         if bin_name == 'bundler' || bin_name == 'bundle'
-                            io.puts shim_bundler(ruby_executable, autoproj_gemfile_path, gems_gem_home)
+                            io.puts shim_bundler(ruby_executable,
+                                autoproj_gemfile_path, gems_gem_home)
                         else
                             load_line = bin_script_lines.grep(/load Gem.bin_path/).first
-                            io.puts shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+                            io.puts shim_script(ruby_executable, root_dir,
+                                autoproj_gemfile_path, gems_gem_home, load_line)
                         end
                     end
                     FileUtils.chmod 0755, bin_shim
@@ -389,8 +415,9 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
 
 load Gem.bin_path('bundler', 'bundler')"
             end
-            
-            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+
+            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path,
+                gems_gem_home, load_line)
 "#! #{ruby_executable}
 
 if defined?(Bundler)
@@ -452,9 +479,10 @@ require 'bundler/setup'
                     "if File.file?(config_path)",
                     "    require 'yaml'",
                     "    config = YAML.load(File.read(config_path)) || Hash.new",
-                    "    (config['plugins'] || Hash.new).each do |plugin_name, (version, options)|",
-                    "        gem plugin_name, version, **options",
-                    "    end",
+                    "    (config['plugins'] || Hash.new).",
+                    "        each do |plugin_name, (version, options)|",
+                    "            gem plugin_name, version, **options",
+                    "        end",
                     "end"
                 ].join("\n")
 
@@ -468,7 +496,8 @@ require 'bundler/setup'
 
 
             def find_in_clean_path(command, *additional_paths)
-                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) + additional_paths
+                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) +
+                    additional_paths
                 clean_path.each do |p|
                     full_path = File.join(p, command)
                     if File.file?(full_path)
@@ -492,7 +521,8 @@ require 'bundler/setup'
                 #
                 # So, we're calling 'gem' as a subcommand to discovery the
                 # actual bindir
-                bindir = IO.popen(env_for_child, [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
+                bindir = IO.popen(env_for_child,
+                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
                 if bindir
                     @gem_bindir = bindir.chomp
                 else
@@ -502,7 +532,9 @@ require 'bundler/setup'
 
             def install
                 if ENV['BUNDLER_GEMFILE']
-                    raise "cannot run autoproj_install or autoproj_bootstrap while under a 'bundler exec' subcommand or having loaded an env.sh. Open a new console and try again"
+                    raise "cannot run autoproj_install or autoproj_bootstrap while "\
+                        "under a 'bundler exec' subcommand or having loaded an env.sh. "\
+                        "Open a new console and try again"
                 end
 
                 gem_program  = self.class.guess_gem_program
@@ -532,7 +564,7 @@ require 'bundler/setup'
 
             def load_config
                 v1_config_path = File.join(root_dir, 'autoproj', 'config.yml')
-                
+
                 config = Hash.new
                 if File.file?(v1_config_path)
                     config.merge!(YAML.load(File.read(v1_config_path)) || Hash.new)
@@ -546,7 +578,10 @@ require 'bundler/setup'
                 ruby_executable = File.join(ruby_bindir, ruby)
                 if current = config['ruby_executable'] # When upgrading or reinstalling
                     if current != ruby_executable
-                        raise "this workspace has already been initialized using #{current}, you cannot run autoproj install with #{ruby_executable}. If you know what you're doing, delete the ruby_executable line in config.yml and try again"
+                        raise "this workspace has already been initialized using "\
+                        "#{current}, you cannot run autoproj install with "\
+                        "#{ruby_executable}. If you know what you're doing, "\
+                        "delete the ruby_executable line in config.yml and try again"
                     end
                 else
                     config['ruby_executable'] = ruby_executable
@@ -605,21 +640,22 @@ require 'bundler/setup'
                 save_env_sh(*vars)
                 puts "running 'autoproj envsh' to generate a proper env.sh"
                 if !system(Gem.ruby, autoproj_path, 'envsh', *autoproj_options)
-                    STDERR.puts "failed to run autoproj envsh on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj envsh on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
                 # This is really needed on an existing install to install the
                 # gems that were present in the v1 layout
                 puts "running 'autoproj osdeps' to re-install missing gems"
                 if !system(Gem.ruby, autoproj_path, 'osdeps')
-                    STDERR.puts "failed to run autoproj osdeps on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj osdeps on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
             end
         end
     end
 end
-
 
 
 ENV.delete('BUNDLE_GEMFILE')

--- a/lib/autoproj/cli/build.rb
+++ b/lib/autoproj/cli/build.rb
@@ -13,7 +13,7 @@ module Autoproj
                     options[:deps] = false
                 end
                 if options[:deps].nil?
-                    options[:deps] = 
+                    options[:deps] =
                         !(options[:rebuild] || options[:force])
                 end
                 return selected_packages, options
@@ -78,11 +78,10 @@ module Autoproj
                 Autobuild.do_build = true
                 ops.build_packages(source_packages, parallel: parallel)
                 Autobuild.apply(source_packages, "autoproj-build", ['install'])
+                Main.run_post_command_hook(:build, ws, source_packages: source_packages)
             ensure
                 export_env_sh
             end
         end
     end
 end
-
-

--- a/lib/autoproj/cli/osdeps.rb
+++ b/lib/autoproj/cli/osdeps.rb
@@ -29,8 +29,9 @@ module Autoproj
                     run_package_managers_without_packages: true,
                     install_only: !update)
                 export_env_sh(shell_helpers: shell_helpers)
+                Main.run_post_command_hook(:update, ws, source_packages: [],
+                    osdep_packages: osdep_packages)
             end
         end
     end
 end
-

--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -66,7 +66,7 @@ module Autoproj
                 return selection, options
             end
 
-            def run(selected_packages, options)
+            def run(selected_packages, run_hook: false, **options)
                 ws.manifest.accept_unavailable_osdeps = !options[:osdeps]
                 ws.setup
                 ws.autodetect_operating_system(force: true)
@@ -125,6 +125,18 @@ module Autoproj
 
                 if options[:osdeps] && !osdep_packages.empty?
                     ws.install_os_packages(osdep_packages, **osdeps_options)
+                end
+
+                if run_hook
+                    if options[:osdeps]
+                        CLI::Main.run_post_command_hook(:update, ws,
+                            source_packages: source_packages,
+                            osdep_packages: osdep_packages)
+                    else
+                        CLI::Main.run_post_command_hook(:update, ws,
+                            source_packages: source_packages,
+                            osdep_packages: [])
+                    end
                 end
 
                 export_env_sh

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -47,7 +47,10 @@ module Autoproj
 
                 load_config
                 if config['ruby_executable'] != Gem.ruby
-                    raise "this autoproj installation was already bootstrapped using #{config['ruby_executable']}, but you are currently running under #{Gem.ruby}. Changing the ruby interpreter in a given workspace is not supported, you need to do a clean bootstrap"
+                    raise "this autoproj installation was already bootstrapped using "\
+                        "#{config['ruby_executable']}, but you are currently running "\
+                        "under #{Gem.ruby}. Changing the ruby interpreter in a given "\
+                        "workspace is not supported, you need to do a clean bootstrap"
                 end
                 @ruby_executable = config['ruby_executable']
                 @local = false
@@ -137,7 +140,9 @@ module Autoproj
             # The GEM_HOME under which the workspace's gems should be installed
             #
             # @return [String]
-            def gems_gem_home; File.join(gems_install_path, gem_path_suffix) end
+            def gems_gem_home
+                File.join(gems_install_path, gem_path_suffix)
+            end
             # Sets where the workspace's gems should be installed
             #
             # @param [String] path the absolute path that should be given to
@@ -174,9 +179,13 @@ module Autoproj
             # Whether autoproj should prefer OS-independent packages over their
             # OS-packaged equivalents (e.g. the thor gem vs. the ruby-thor
             # Debian package)
-            def prefer_indep_over_os_packages?; @prefer_indep_over_os_packages end
+            def prefer_indep_over_os_packages?
+                @prefer_indep_over_os_packages
+            end
             # (see #prefer_index_over_os_packages?)
-            def prefer_indep_over_os_packages=(flag); @prefer_indep_over_os_packages = !!flag end
+            def prefer_indep_over_os_packages=(flag)
+                @prefer_indep_over_os_packages = !!flag
+            end
 
             def self.guess_gem_program
                 ruby_bin = RbConfig::CONFIG['RUBY_INSTALL_NAME']
@@ -192,7 +201,8 @@ module Autoproj
                         return gem_full_path
                     end
                 end
-                raise ArgumentError, "cannot find a gem program (tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
+                raise ArgumentError, "cannot find a gem program "\
+                    "(tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
             end
 
             # The content of the default {#gemfile}
@@ -216,39 +226,48 @@ module Autoproj
                     opt.on '--skip-stage2', 'do not run the stage2 install' do
                         @skip_stage2 = true
                     end
-                    opt.on '--gem-source=URL', String, "use this source for RubyGems instead of rubygems.org" do |url|
+                    opt.on '--gem-source=URL', String, "use this source for RubyGems "\
+                        "instead of rubygems.org" do |url|
                         @gem_source = url
                     end
-                    opt.on '--gems-path=PATH', "install gems under this path instead of ~/.autoproj/gems" do |path|
+                    opt.on '--gems-path=PATH', "install gems under this path instead "\
+                        "of ~/.autoproj/gems" do |path|
                         self.gems_install_path     = path
                     end
                     opt.on '--public-gems', "install gems in the default gem location" do
                         self.install_gems_in_gem_user_dir
                     end
-                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided string as a version constraint for autoproj' do |version|
+                    opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided "\
+                        "string as a version constraint for autoproj' do |version|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = default_gemfile_contents(version)
                     end
-                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install autoproj instead of the default' do |path|
+                    opt.on '--gemfile=PATH', String, 'use the given Gemfile to install "\
+                        "autoproj instead of the default' do |path|
                         if @gemfile
                             raise "cannot give both --version and --gemfile"
                         end
                         @gemfile = File.read(path)
                     end
-                    opt.on '--seed-config=PATH', String, 'path to a seed file that should be used to initialize the configuration' do |path|
+                    opt.on '--seed-config=PATH', String, 'path to a seed file that "\
+                        "should be used to initialize the configuration' do |path|
                         @config.merge!(YAML.load(File.read(path)))
                     end
-                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent packages (such as a RubyGem) over their OS-packaged equivalent (e.g. the thor gem vs. the ruby-thor debian package)' do
+                    opt.on '--prefer-os-independent-packages', 'prefer OS-independent "\
+                        "packages (such as a RubyGem) over their OS-packaged equivalent "\
+                        "(e.g. the thor gem vs. the ruby-thor debian package)' do
                         @prefer_indep_over_os_packages = true
                     end
-                    opt.on '--[no-]color', 'do not use colored output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]color', 'do not use colored output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--color"
                         else autoproj_options << '--no-color'
                         end
                     end
-                    opt.on '--[no-]progress', 'do not use progress output (enabled by default if the terminal supports it)' do |color|
+                    opt.on '--[no-]progress', 'do not use progress output (enabled by "\
+                        "default if the terminal supports it)' do |color|
                         if color then autoproj_options << "--progress"
                         else autoproj_options << '--no-progress'
                         end
@@ -281,9 +300,11 @@ module Autoproj
 
                 result = system(
                     env_for_child.merge('GEM_HOME' => gems_gem_home),
-                    Gem.ruby, gem_program, 'install', '--env-shebang', '--no-document', '--no-format-executable', '--clear-sources', '--source', gem_source,
-                        *local,
-                        "--bindir=#{File.join(gems_gem_home, 'bin')}", 'bundler', **redirection)
+                    Gem.ruby, gem_program, 'install',
+                        '--env-shebang', '--no-document', '--no-format-executable',
+                        '--clear-sources', '--source', gem_source,
+                        *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
+                        'bundler', **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
@@ -294,14 +315,15 @@ module Autoproj
                 if File.exist?(bundler_path)
                     bundler_path
                 else
-                    STDERR.puts "gem install bundler returned successfully, but still cannot find bundler in #{bundler_path}"
+                    STDERR.puts "gem install bundler returned successfully, but still "\
+                        "cannot find bundler in #{bundler_path}"
                     nil
                 end
             end
 
             def install_autoproj(bundler)
-                # Force bundler to update. If the user does not want this, let him specify a
-                # Gemfile with tighter version constraints
+                # Force bundler to update. If the user does not want this, let
+                # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, 'Gemfile.lock')
                 if File.exist?(lockfile)
                     FileUtils.rm lockfile
@@ -325,12 +347,14 @@ module Autoproj
                     exit 1
                 end
             ensure
-                self.class.rewrite_shims(shims_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+                self.class.rewrite_shims(shims_path, ruby_executable,
+                    root_dir, autoproj_gemfile_path, gems_gem_home)
             end
 
             EXCLUDED_FROM_SHIMS = %w{rake thor}
 
-            def self.rewrite_shims(shim_path, ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home)
+            def self.rewrite_shims(shim_path, ruby_executable,
+                root_dir, autoproj_gemfile_path, gems_gem_home)
                 FileUtils.mkdir_p shim_path
                 File.open(File.join(shim_path, 'ruby'), 'w') do |io|
                     io.puts "#! /bin/sh"
@@ -353,10 +377,12 @@ module Autoproj
                     bin_script_lines = File.readlines(bin_script)
                     File.open(bin_shim, 'w') do |io|
                         if bin_name == 'bundler' || bin_name == 'bundle'
-                            io.puts shim_bundler(ruby_executable, autoproj_gemfile_path, gems_gem_home)
+                            io.puts shim_bundler(ruby_executable,
+                                autoproj_gemfile_path, gems_gem_home)
                         else
                             load_line = bin_script_lines.grep(/load Gem.bin_path/).first
-                            io.puts shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+                            io.puts shim_script(ruby_executable, root_dir,
+                                autoproj_gemfile_path, gems_gem_home, load_line)
                         end
                     end
                     FileUtils.chmod 0755, bin_shim
@@ -380,7 +406,8 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
 load Gem.bin_path('bundler', 'bundler')"
             end
 
-            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path, gems_gem_home, load_line)
+            def self.shim_script(ruby_executable, root_dir, autoproj_gemfile_path,
+                gems_gem_home, load_line)
 "#! #{ruby_executable}
 
 if defined?(Bundler)
@@ -442,9 +469,10 @@ require 'bundler/setup'
                     "if File.file?(config_path)",
                     "    require 'yaml'",
                     "    config = YAML.load(File.read(config_path)) || Hash.new",
-                    "    (config['plugins'] || Hash.new).each do |plugin_name, (version, options)|",
-                    "        gem plugin_name, version, **options",
-                    "    end",
+                    "    (config['plugins'] || Hash.new).",
+                    "        each do |plugin_name, (version, options)|",
+                    "            gem plugin_name, version, **options",
+                    "        end",
                     "end"
                 ].join("\n")
 
@@ -458,7 +486,8 @@ require 'bundler/setup'
 
 
             def find_in_clean_path(command, *additional_paths)
-                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) + additional_paths
+                clean_path = env_for_child['PATH'].split(File::PATH_SEPARATOR) +
+                    additional_paths
                 clean_path.each do |p|
                     full_path = File.join(p, command)
                     if File.file?(full_path)
@@ -482,7 +511,8 @@ require 'bundler/setup'
                 #
                 # So, we're calling 'gem' as a subcommand to discovery the
                 # actual bindir
-                bindir = IO.popen(env_for_child, [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
+                bindir = IO.popen(env_for_child,
+                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
                 if bindir
                     @gem_bindir = bindir.chomp
                 else
@@ -492,7 +522,9 @@ require 'bundler/setup'
 
             def install
                 if ENV['BUNDLER_GEMFILE']
-                    raise "cannot run autoproj_install or autoproj_bootstrap while under a 'bundler exec' subcommand or having loaded an env.sh. Open a new console and try again"
+                    raise "cannot run autoproj_install or autoproj_bootstrap while "\
+                        "under a 'bundler exec' subcommand or having loaded an env.sh. "\
+                        "Open a new console and try again"
                 end
 
                 gem_program  = self.class.guess_gem_program
@@ -536,7 +568,10 @@ require 'bundler/setup'
                 ruby_executable = File.join(ruby_bindir, ruby)
                 if current = config['ruby_executable'] # When upgrading or reinstalling
                     if current != ruby_executable
-                        raise "this workspace has already been initialized using #{current}, you cannot run autoproj install with #{ruby_executable}. If you know what you're doing, delete the ruby_executable line in config.yml and try again"
+                        raise "this workspace has already been initialized using "\
+                        "#{current}, you cannot run autoproj install with "\
+                        "#{ruby_executable}. If you know what you're doing, "\
+                        "delete the ruby_executable line in config.yml and try again"
                     end
                 else
                     config['ruby_executable'] = ruby_executable
@@ -595,14 +630,16 @@ require 'bundler/setup'
                 save_env_sh(*vars)
                 puts "running 'autoproj envsh' to generate a proper env.sh"
                 if !system(Gem.ruby, autoproj_path, 'envsh', *autoproj_options)
-                    STDERR.puts "failed to run autoproj envsh on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj envsh on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
                 # This is really needed on an existing install to install the
                 # gems that were present in the v1 layout
                 puts "running 'autoproj osdeps' to re-install missing gems"
                 if !system(Gem.ruby, autoproj_path, 'osdeps')
-                    STDERR.puts "failed to run autoproj osdeps on the newly installed autoproj (#{autoproj_path})"
+                    STDERR.puts "failed to run autoproj osdeps on the newly installed "\
+                        "autoproj (#{autoproj_path})"
                     exit 1
                 end
             end

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -3,7 +3,15 @@ require 'xdg'
 
 module Autoproj
     class Workspace < Ops::Loader
+        # The workspace root as a string
+        #
+        # New code should prefer {#root_path}
         attr_reader :root_dir
+
+        # The workspace root
+        #
+        # This should be used rather than {#root_dir} in new code
+        attr_reader :root_path
 
         attr_accessor :config
         attr_reader :env
@@ -45,6 +53,7 @@ module Autoproj
                        os_package_resolver: OSPackageResolver.new,
                        package_managers: OSPackageInstaller::PACKAGE_MANAGERS)
             @root_dir = root_dir
+            @root_path = Pathname.new(root_dir)
             @ruby_version_keyword = "ruby#{RUBY_VERSION.split('.')[0, 2].join("")}"
             @osdep_suffixes = Array.new
 

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -360,7 +360,8 @@ module Autoproj
         def rewrite_shims
             gemfile  = File.join(dot_autoproj_dir, 'Gemfile')
             binstubs = File.join(dot_autoproj_dir, 'bin')
-            Ops::Install.rewrite_shims(binstubs, config.ruby_executable, root_dir, gemfile, config.gems_gem_home)
+            Ops::Install.rewrite_shims(binstubs, config.ruby_executable,
+                root_dir, gemfile, config.gems_gem_home)
         end
 
         def update_bundler
@@ -448,7 +449,7 @@ module Autoproj
             if block_given?
                 begin
                     yield
-                ensure 
+                ensure
                     clear_main_workspace
                 end
             end
@@ -585,7 +586,7 @@ module Autoproj
         def load_all_available_package_manifests
             manifest.load_all_available_package_manifests
         end
-        
+
         def setup_all_package_directories
             # Override the package directories from our reused installations
             imported_packages = Set.new
@@ -639,7 +640,7 @@ module Autoproj
             pkg.doc_target_dir = File.join(prefix_dir, 'doc', pkg_name)
             pkg.logdir = File.join(pkg.prefix, "log")
         end
-        
+
         def compute_builddir(pkg)
             # If we're given an absolute build dir, we have to append the
             # package name to it to make it unique
@@ -813,7 +814,7 @@ module Autoproj
         # `cmd` is not executable. Otherwise, looks for an executable named
         # `cmd` in PATH and returns it, or raises if it cannot be found. The
         # exception contains a more detailed reason for failure
-        # 
+        #
         #
         # @param [String] cmd
         # @return [String] the resolved program
@@ -839,4 +840,3 @@ module Autoproj
         workspace.env
     end
 end
-


### PR DESCRIPTION
These hooks allow plugins to execute code after overall operations
such as build and update.

This is introduced for the [autoproj-sync plugin](https://github.com/rock-core/autoproj-sync), so that it can [automatically synchronise after a build or update](https://github.com/rock-core/autoproj-sync#automated-synchronisation)

See the documentation of register_post_command_hook for the list
of available hooks and their documentation