### PR TITLE
fix some more corner-cases related to moving bundler in .local/

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -50,8 +50,6 @@ module Autoproj
                 @env = Hash.new
                 env['RUBYOPT'] = []
                 env['RUBYLIB'] = []
-                env['GEM_PATH'] = []
-                env['GEM_HOME'] = []
                 env['PATH'] = self.class.sanitize_env(ENV['PATH'] || "")
                 env['BUNDLE_GEMFILE'] = []
 
@@ -66,6 +64,8 @@ module Autoproj
                 @local = false
 
                 install_gems_in_gem_user_dir
+                env['GEM_HOME'] = [gems_gem_home]
+                env['GEM_PATH'] = [gems_gem_home]
             end
 
             def env_for_child(env = self.env)

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -68,7 +68,7 @@ module Autoproj
                 install_gems_in_gem_user_dir
             end
 
-            def env_for_child
+            def env_for_child(env = self.env)
                 env.inject(Hash.new) do |h, (k, v)|
                     h[k] = if v && !v.empty? then v.join(File::PATH_SEPARATOR)
                            end
@@ -308,8 +308,11 @@ module Autoproj
                     redirection = Hash[out: :close]
                 end
 
+                # Shut up the bundler warning about 'bin' not being in PATH
+                env = self.env
+                env['PATH'] += [File.join(gems_gem_home, 'bin')]
                 result = system(
-                    env_for_child,
+                    env_for_child(env),
                     Gem.ruby, gem_program, 'install',
                         '--env-shebang', '--no-document', '--no-format-executable',
                         '--clear-sources', '--source', gem_source,

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -288,14 +288,14 @@ module Autoproj
             end
 
             def find_bundler(gem_program)
-                result = system(
-                    env_for_child,
-                    Gem.ruby, gem_program, 'which', 'bundler/setup',
-                    out: '/dev/null')
-                return if !result
+                setup_path =
+                    IO.popen([env_for_child, Gem.ruby, gem_program, 'which', 'bundler/setup']) do |io|
+                        io.read
+                    end
+                return unless $?.success?
 
                 bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                if File.exist?(bundler_path)
+                if File.exist?(bundler_path) && setup_path.start_with?(gems_gem_home)
                     bundler_path
                 end
             end
@@ -309,24 +309,24 @@ module Autoproj
                 end
 
                 result = system(
-                    env_for_child.merge('GEM_HOME' => gems_gem_home),
+                    env_for_child,
                     Gem.ruby, gem_program, 'install',
                         '--env-shebang', '--no-document', '--no-format-executable',
                         '--clear-sources', '--source', gem_source,
+                        '--no-user-install', '--install-dir', gems_gem_home,
                         *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
-                        'bundle', **redirection)
+                        'bundler', **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
                     nil
                 end
 
-                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                if File.exist?(bundler_path)
+                if (bundler_path = find_bundler(gem_program))
                     bundler_path
                 else
                     STDERR.puts "gem install bundler returned successfully, but still "\
-                        "cannot find bundler in #{bundler_path}"
+                        "cannot find bundler in #{gems_gem_home}"
                     nil
                 end
             end
@@ -603,6 +603,7 @@ require 'bundler/setup'
                 gem_program  = self.class.guess_gem_program
                 puts "Detected 'gem' to be #{gem_program}"
                 env['GEM_HOME'] = [gems_gem_home]
+                env['GEM_PATH'] = [gems_gem_home]
 
                 if bundler = find_bundler(gem_program)
                     puts "Detected bundler at #{bundler}"

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -54,6 +54,7 @@ module Autoproj
                 env['BUNDLE_GEMFILE'] = []
 
                 load_config
+
                 if config['ruby_executable'] != Gem.ruby
                     raise "this autoproj installation was already bootstrapped using "\
                         "#{config['ruby_executable']}, but you are currently running "\
@@ -63,7 +64,9 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                install_gems_in_gem_user_dir
+                unless @gems_install_path
+                    install_gems_in_gem_user_dir
+                end
                 env['GEM_HOME'] = [gems_gem_home]
                 env['GEM_PATH'] = [gems_gem_home]
             end

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -50,8 +50,6 @@ module Autoproj
                 @env = Hash.new
                 env['RUBYOPT'] = []
                 env['RUBYLIB'] = []
-                env['GEM_PATH'] = []
-                env['GEM_HOME'] = []
                 env['PATH'] = self.class.sanitize_env(ENV['PATH'] || "")
                 env['BUNDLE_GEMFILE'] = []
 
@@ -66,6 +64,8 @@ module Autoproj
                 @local = false
 
                 install_gems_in_gem_user_dir
+                env['GEM_HOME'] = [gems_gem_home]
+                env['GEM_PATH'] = [gems_gem_home]
             end
 
             def env_for_child(env = self.env)

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -68,7 +68,7 @@ module Autoproj
                 install_gems_in_gem_user_dir
             end
 
-            def env_for_child
+            def env_for_child(env = self.env)
                 env.inject(Hash.new) do |h, (k, v)|
                     h[k] = if v && !v.empty? then v.join(File::PATH_SEPARATOR)
                            end
@@ -308,8 +308,11 @@ module Autoproj
                     redirection = Hash[out: :close]
                 end
 
+                # Shut up the bundler warning about 'bin' not being in PATH
+                env = self.env
+                env['PATH'] += [File.join(gems_gem_home, 'bin')]
                 result = system(
-                    env_for_child,
+                    env_for_child(env),
                     Gem.ruby, gem_program, 'install',
                         '--env-shebang', '--no-document', '--no-format-executable',
                         '--clear-sources', '--source', gem_source,

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -288,14 +288,14 @@ module Autoproj
             end
 
             def find_bundler(gem_program)
-                result = system(
-                    env_for_child,
-                    Gem.ruby, gem_program, 'which', 'bundler/setup',
-                    out: '/dev/null')
-                return if !result
+                setup_path =
+                    IO.popen([env_for_child, Gem.ruby, gem_program, 'which', 'bundler/setup']) do |io|
+                        io.read
+                    end
+                return unless $?.success?
 
                 bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                if File.exist?(bundler_path)
+                if File.exist?(bundler_path) && setup_path.start_with?(gems_gem_home)
                     bundler_path
                 end
             end
@@ -309,24 +309,24 @@ module Autoproj
                 end
 
                 result = system(
-                    env_for_child.merge('GEM_HOME' => gems_gem_home),
+                    env_for_child,
                     Gem.ruby, gem_program, 'install',
                         '--env-shebang', '--no-document', '--no-format-executable',
                         '--clear-sources', '--source', gem_source,
+                        '--no-user-install', '--install-dir', gems_gem_home,
                         *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
-                        'bundle', **redirection)
+                        'bundler', **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
                     nil
                 end
 
-                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                if File.exist?(bundler_path)
+                if (bundler_path = find_bundler(gem_program))
                     bundler_path
                 else
                     STDERR.puts "gem install bundler returned successfully, but still "\
-                        "cannot find bundler in #{bundler_path}"
+                        "cannot find bundler in #{gems_gem_home}"
                     nil
                 end
             end
@@ -603,6 +603,7 @@ require 'bundler/setup'
                 gem_program  = self.class.guess_gem_program
                 puts "Detected 'gem' to be #{gem_program}"
                 env['GEM_HOME'] = [gems_gem_home]
+                env['GEM_PATH'] = [gems_gem_home]
 
                 if bundler = find_bundler(gem_program)
                     puts "Detected bundler at #{bundler}"

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -54,6 +54,7 @@ module Autoproj
                 env['BUNDLE_GEMFILE'] = []
 
                 load_config
+
                 if config['ruby_executable'] != Gem.ruby
                     raise "this autoproj installation was already bootstrapped using "\
                         "#{config['ruby_executable']}, but you are currently running "\
@@ -63,7 +64,9 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                install_gems_in_gem_user_dir
+                unless @gems_install_path
+                    install_gems_in_gem_user_dir
+                end
                 env['GEM_HOME'] = [gems_gem_home]
                 env['GEM_PATH'] = [gems_gem_home]
             end

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -40,8 +40,6 @@ module Autoproj
                 @env = Hash.new
                 env['RUBYOPT'] = []
                 env['RUBYLIB'] = []
-                env['GEM_PATH'] = []
-                env['GEM_HOME'] = []
                 env['PATH'] = self.class.sanitize_env(ENV['PATH'] || "")
                 env['BUNDLE_GEMFILE'] = []
 
@@ -56,6 +54,8 @@ module Autoproj
                 @local = false
 
                 install_gems_in_gem_user_dir
+                env['GEM_HOME'] = [gems_gem_home]
+                env['GEM_PATH'] = [gems_gem_home]
             end
 
             def env_for_child(env = self.env)

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -58,7 +58,7 @@ module Autoproj
                 install_gems_in_gem_user_dir
             end
 
-            def env_for_child
+            def env_for_child(env = self.env)
                 env.inject(Hash.new) do |h, (k, v)|
                     h[k] = if v && !v.empty? then v.join(File::PATH_SEPARATOR)
                            end
@@ -298,8 +298,11 @@ module Autoproj
                     redirection = Hash[out: :close]
                 end
 
+                # Shut up the bundler warning about 'bin' not being in PATH
+                env = self.env
+                env['PATH'] += [File.join(gems_gem_home, 'bin')]
                 result = system(
-                    env_for_child,
+                    env_for_child(env),
                     Gem.ruby, gem_program, 'install',
                         '--env-shebang', '--no-document', '--no-format-executable',
                         '--clear-sources', '--source', gem_source,

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -44,6 +44,7 @@ module Autoproj
                 env['BUNDLE_GEMFILE'] = []
 
                 load_config
+
                 if config['ruby_executable'] != Gem.ruby
                     raise "this autoproj installation was already bootstrapped using "\
                         "#{config['ruby_executable']}, but you are currently running "\
@@ -53,7 +54,9 @@ module Autoproj
                 @ruby_executable = config['ruby_executable']
                 @local = false
 
-                install_gems_in_gem_user_dir
+                unless @gems_install_path
+                    install_gems_in_gem_user_dir
+                end
                 env['GEM_HOME'] = [gems_gem_home]
                 env['GEM_PATH'] = [gems_gem_home]
             end

--- a/lib/autoproj/version.rb
+++ b/lib/autoproj/version.rb
@@ -1,3 +1,3 @@
 module Autoproj
-    VERSION = "2.8.6"
+    VERSION = "2.8.7"
 end


### PR DESCRIPTION
The main issue is that Gem would pick up a bundler already installed
in $HOME/.gem, which would work until we get to our shims, which
reset GEM_HOME and GEM_PATH to ensure an isolation of the Autoproj
workspace gems.

Make sure the bundler we find is indeed in #gems_gem_home, and
that it gets installed there regardless of the state of the rest
of the system.