### PR TITLE
cli: fix Gemfile generated by `autoproj update <PACKAGE>` when a gem is selected by the manifest

### DIFF
--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -109,7 +109,8 @@ module Autoproj
                 source_packages, osdep_packages, import_failure =
                     update_packages(
                         selected_packages,
-                        osdeps: options[:osdeps], osdeps_options: osdeps_options,
+                        osdeps: options[:osdeps],
+                        osdeps_options: osdeps_options,
                         from: options[:from],
                         checkout_only: options[:checkout_only],
                         only_local: options[:only_local],

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -892,16 +892,14 @@ module Autoproj
         #
         # @return [Array<PackageDefinition>]
         def all_selected_source_packages(validate = true)
-            result = Set.new
-            selection = default_packages(validate)
+            default_packages(validate).all_selected_source_packages(self)
+        end
 
-            root_sources = selection.each_source_package_name.to_set
-            root_sources.each do |pkg_name|
-                find_autobuild_package(pkg_name).all_dependencies(result)
-            end
-            result.merge(root_sources).map do |pkg_name|
-                find_package_definition(pkg_name)
-            end
+        # Returns the set of osdep packages that are selected by the layout
+        #
+        # @return [Array<String>]
+        def all_selected_osdep_packages(validate = true)
+            default_packages(validate).all_selected_osdep_packages(self)
         end
 
         # Returns the set of packages that are selected by the layout

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -775,11 +775,7 @@ module Autoproj
                                     retry_count: 0)
                 all_os_packages
             else
-                result = Set.new
-                manifest.all_selected_source_packages.each do |source_package|
-                    result.merge(source_package.autobuild.os_packages)
-                end
-                result
+                manifest.all_selected_osdep_packages
             end
         end
 

--- a/test/test_package_selection.rb
+++ b/test/test_package_selection.rb
@@ -1,0 +1,91 @@
+require 'autoproj/test'
+
+module Autoproj
+    describe PackageSelection do
+        before do
+            @sel = PackageSelection.new
+        end
+
+        it "is empty on creation" do
+            assert @sel.empty?
+        end
+
+        describe "#select" do
+            it "registers a set of source packages" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"])
+                assert_equal ["pkg1", "pkg2"], @sel.each_source_package_name.to_a
+                assert_equal [], @sel.each_osdep_package_name.to_a
+            end
+            it "registers a selected osdep package" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"], osdep: true)
+                assert_equal [], @sel.each_source_package_name.to_a
+                assert_equal ["pkg1", "pkg2"], @sel.each_osdep_package_name.to_a
+            end
+            it "registers why a package was selected" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"])
+                assert_equal ["because_of_this"], @sel.selection['pkg1'].to_a
+                assert_equal ["because_of_this"], @sel.selection['pkg2'].to_a
+            end
+            it "registers what matched a given selection" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"])
+                assert Set['pkg1', 'pkg2'], @sel.match_for('because_of_this')
+            end
+            it "registers a non-weak match by default" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"])
+                refute @sel.weak_dependencies['because_of_this']
+            end
+            it "records that the selection is weak" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"], weak: true)
+                assert @sel.weak_dependencies['because_of_this']
+            end
+            it "treats a last argument as the 'weak' flag (compat)" do
+                @sel.select("because_of_this", ["pkg1", "pkg2"], true)
+                assert @sel.weak_dependencies['because_of_this']
+            end
+        end
+
+        describe "#all_selected_source_packages" do
+            before do
+                @ws = ws_create
+                @pkg1 = ws_define_package :cmake, 'pkg1'
+                @pkg2 = ws_define_package :cmake, 'pkg2'
+                @pkg1.depends_on @pkg2
+            end
+
+            it "returns the set of source packages and their dependencies" do
+                @sel.select("pkg1", "pkg1")
+                assert_equal Set[@pkg1, @pkg2],
+                    @sel.all_selected_source_packages(ws.manifest).to_set
+            end
+
+            it "does not return osdeps" do
+                @sel.select("pkg1", "pkg1", osdep: true)
+                assert @sel.all_selected_source_packages(ws.manifest).empty?
+            end
+        end
+
+        describe "#all_selected_osdep_packages" do
+            before do
+                @ws = ws_create
+                @pkg1 = ws_define_package :cmake, 'pkg1'
+                @pkg2 = ws_define_package :cmake, 'pkg2'
+                @pkg1.depends_on @pkg2
+                @pkg1.autobuild.os_packages << "osdep1"
+                @pkg2.autobuild.os_packages << "osdep2"
+            end
+
+            it "returns the set of osdep packages selected by the source packages" do
+                @sel.select("pkg1", "pkg1")
+                assert_equal %w[osdep1 osdep2],
+                    @sel.all_selected_osdep_packages(ws.manifest).to_a.sort
+            end
+
+            it "adds any directly selected osdep package" do
+                @sel.select("pkg1", "pkg1")
+                @sel.select("osdep3", "osdep3", osdep: true)
+                assert_equal %w[osdep1 osdep2 osdep3],
+                    @sel.all_selected_osdep_packages(ws.manifest).to_a.sort
+            end
+        end
+    end
+end


### PR DESCRIPTION
When calling update with a specific package selection, the codepath
is different than when all packages are selected. In this codepath,
only the osdeps from the selected source packages were passed to
the package managers, which was causing the Gemfile generated for
bundler to be partial.

Closes #233