### PR TITLE
simplify osrepos format

### DIFF
--- a/test/data/test.osrepos
+++ b/test/data/test.osrepos
@@ -1,4 +1,4 @@
 ---
 - ubuntu:
    - xenial:
-     type: repo
+     - type: repo

--- a/test/test_os_repository_resolver.rb
+++ b/test/test_os_repository_resolver.rb
@@ -8,7 +8,7 @@ module Autoproj
 
         before do
             @subject = OSRepositoryResolver.new
-            @definitions = [{ 'ubuntu' => [{ 'xenial' => nil, 'type' => 'repo' }] }]
+            @definitions = [{ 'ubuntu' => [{ 'xenial' => [{ 'type' => 'repo' }] }] }]
         end
 
         describe '#load' do
@@ -32,7 +32,7 @@ module Autoproj
         end
         describe '#merge' do
             it 'merges definitions in the receiver' do
-                new_defs = [{ 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }]
+                new_defs = [{ 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }]
                 new_resolver = OSRepositoryResolver.new(new_defs, '/path/to/some.osrepos')
 
                 @subject = OSRepositoryResolver.new(definitions, '/foo/test.osrepos')
@@ -47,8 +47,8 @@ module Autoproj
         end
         describe '#definitions' do
             it 'returns an array of the merged definitions' do
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
                 @subject = OSRepositoryResolver.new(definitions, '/foo/test.osrepos')
 
                 assert_equal subject.definitions, definitions.uniq
@@ -56,8 +56,8 @@ module Autoproj
         end
         describe '#all_entries' do
             it 'returns an array of the merged entries' do
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
                 @subject = OSRepositoryResolver.new(definitions, '/foo/test.osrepos')
 
                 assert_equal subject.all_entries, [{ 'type' => 'repo' }, { 'type' => 'key' }]
@@ -65,8 +65,8 @@ module Autoproj
         end
         describe '#resolved_entries' do
             it 'returns an array of the entries valid for this OS' do
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'key' }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'key' }] }] }
 
                 @subject = OSRepositoryResolver.new(
                     definitions,
@@ -79,8 +79,8 @@ module Autoproj
         end
         describe '#resolved_entries' do
             it 'allows "default" as a release name while resolving entries' do
-                definitions << { 'ubuntu' => [{ 'default' => nil, 'type' => 'key' }] }
-                definitions << { 'debian' => [{ 'jessie' => nil, 'type' => 'foo' }] }
+                definitions << { 'ubuntu' => [{ 'default' => [{ 'type' => 'key' }] }] }
+                definitions << { 'debian' => [{ 'jessie' => [{ 'type' => 'foo' }] }] }
 
                 @subject = OSRepositoryResolver.new(
                     definitions,
@@ -113,7 +113,7 @@ module Autoproj
                 end
             end
             it 'does not throw if definitions are valid' do
-                OSRepositoryResolver.verify_definitions([{ 'ubuntu' => [{ 'xenial' => nil, 'type' => 'repo' }] }])
+                OSRepositoryResolver.verify_definitions([{ 'ubuntu' => [{ 'xenial' => [{ 'type' => 'repo' }] }] }])
             end
         end
     end


### PR DESCRIPTION
This changes the format from:

```yaml
- ubuntu:
  - xenial:
    type: repo
    repo: 'deb http://packages.ros.org/ros/ubuntu xenial main'
  - xenial:
    type: repo
    repo: 'deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main'
  - xenial:
    type: key
    keyserver: 'hkp://ha.pool.sks-keyservers.net:80'
    id: 421C365BD9FF1F717815A3895523BAEEB01FA116
  - xenial:
    type: key
    url: 'http://packages.osrfoundation.org/gazebo.key'
    id: D2486D2DD83DB69272AFE98867170598AF249743
```

to:

```yaml
- ubuntu:
  - xenial:
    - type: repo
      repo: 'deb http://packages.ros.org/ros/ubuntu xenial main'
    - type: repo
      repo: 'deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main'
    - type: key
      keyserver: 'hkp://ha.pool.sks-keyservers.net:80'
      id: 421C365BD9FF1F717815A3895523BAEEB01FA116
    - type: key
      url: 'http://packages.osrfoundation.org/gazebo.key'
      id: D2486D2DD83DB69272AFE98867170598AF249743
```

which is less verbose and looks nicer in my opinion..

Given that the whole feature is not released yet, I am shamelessly breaking backwards compatibility...