### PR TITLE
properly finalize package setup when updating with an empty selection

### DIFF
--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -97,6 +97,8 @@ module Autoproj
                     command_line_selection, selected_packages =
                         finish_loading_configuration(selected_packages)
                 else
+                    ws.setup_all_package_directories
+                    ws.finalize_package_setup
                     command_line_selection, selected_packages = [], PackageSelection.new
                 end
 

--- a/test/cli/test_update.rb
+++ b/test/cli/test_update.rb
@@ -196,6 +196,13 @@ module Autoproj
                         with(hsh(checkout_only: true)).once
                     cli.run([], checkout_only: true)
                 end
+                it "properly sets up packages while updating configuration only" do
+                    flexmock(ws).should_receive(:setup_all_package_directories).
+                        ordered.once
+                    flexmock(ws).should_receive(:finalize_package_setup).
+                        ordered.once
+                    cli.run([], config: true)
+                end
                 it "passes options to the osdep installer for package import" do
                     flexmock(Ops::Import).new_instances.
                         should_receive(:import_packages).


### PR DESCRIPTION
Some code paths skip package setup during update/import operations, i.e:

```console
$ autoproj update --config
```

and

```console
$ autoproj switch-config branch=master
```

This may have unintended consequences specially in post update hooks. Underlying issue: https://github.com/rock-core/autoproj/blob/6ae7ff7a65c98a2bf9bf2536a0d1d6f0ad01a982/lib/autoproj/cli/update.rb#L96