### PR TITLE
watch: workaround rb-inotify breaking when stopping within a callback

### DIFF
--- a/lib/autoproj/cli/watch.rb
+++ b/lib/autoproj/cli/watch.rb
@@ -51,7 +51,7 @@ module Autoproj
             end
 
             def callback
-                notifier.stop
+                Thread.new { notifier.stop }
             end
 
             def create_file_watcher(file)


### PR DESCRIPTION
See https://github.com/guard/rb-inotify/pull/93