### PR TITLE
Permit autoproj to perform configuration noninteractively by relying …

### DIFF
--- a/lib/autoproj/build_option.rb
+++ b/lib/autoproj/build_option.rb
@@ -45,18 +45,35 @@ module Autoproj
             end
         end
 
-        def ask(current_value, doc = nil)
-            default_value =
-                if !current_value.nil? then current_value.to_s
-                elsif options[:default] then options[:default].to_str
-                else ''
-                end
+        # Return either the current value if it is not nil, or use
+        # a default value
+        #
+        # @return [value, Boolean] Current value, and flag whether this is a
+        # default value
+        def ensure_value(current_value)
+            if !current_value.nil?
+                return current_value.to_s, false
+            elsif options[:default]
+                return options[:default].to_str, true
+            else
+                return '', true
+            end
+        end
 
-            STDOUT.print "  #{doc || self.doc} [#{default_value}] "
+        # Ask the user for the setting of this option
+        # by providing the current value as input and falling
+        # back to default values if needed
+        #
+        # @param [String] current_value the option's current value
+        # @param [String] doc a string to override the default option banner
+        def ask(current_value, doc = nil)
+            value,_ = ensure_value(current_value)
+
+            STDOUT.print "  #{doc || self.doc} [#{value}] "
             STDOUT.flush
             answer = STDIN.readline.chomp
             if answer == ''
-                answer = default_value
+                answer = value
             end
             validate(answer)
 

--- a/lib/autoproj/cli/base.rb
+++ b/lib/autoproj/cli/base.rb
@@ -166,6 +166,7 @@ module Autoproj
             end
 
             def validate_options(args, options)
+                ws.config.interactive = options[:interactive]
                 self.class.validate_options(args, options)
             end
 

--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -30,6 +30,8 @@ module Autoproj
                 desc: 'enables or disables colored display (enabled by default if the terminal supports it)'
             class_option :progress, type: :boolean, default: TTY::Color.color?,
                 desc: 'enables or disables progress display (enabled by default if the terminal supports it)'
+            class_option 'interactive', type: :boolean, default: nil,
+                desc: 'tell autoproj to run (non)interactively'
 
             stop_on_unknown_option! :exec
             check_unknown_options!  except: :exec

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -271,7 +271,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
                 os_package_manager: 'os')
         end
 
-        def ws_create(dir = make_tmpdir)
+        def ws_create(dir = make_tmpdir, partial_config: false)
             require 'autoproj/ops/main_config_switcher'
             FileUtils.cp_r Ops::MainConfigSwitcher::MAIN_CONFIGURATION_TEMPLATE, File.join(dir, 'autoproj')
             FileUtils.mkdir_p File.join(dir, '.autoproj')
@@ -280,8 +280,11 @@ gem 'autobuild', path: '#{autobuild_dir}'
             @ws = Workspace.new(
                 dir, os_package_resolver: ws_os_package_resolver,
                      package_managers: ws_package_managers)
-            ws.config.set 'osdeps_mode', 'all'
-            ws.config.set 'apt_dpkg_update', true
+
+            if !partial_config
+                ws.config.set 'osdeps_mode', 'all'
+                ws.config.set 'apt_dpkg_update', true
+            end
             ws.config.set 'GITHUB', 'http,ssh', true
             ws.config.set 'GITORIOUS', 'http,ssh', true
             ws.config.set 'gems_install_path', File.join(dir, 'gems')

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -236,10 +236,16 @@ module Autoproj
             File.join(config_dir, OVERRIDES_DIR)
         end
 
+        # Load the configuration for this workspace from
+        # config_file_path
+        #
+        # @param [Boolean] reset Set to true to replace the configuration object,
+        #   set to false to load into the existing
+        # @return [Configuration] configuration object
         def load_config(reconfigure = false)
-            @config = Configuration.new(config_file_path)
             if File.file?(config_file_path)
-                config.load(reconfigure: reconfigure)
+                config.reset
+                config.load(path: config_file_path, reconfigure: reconfigure)
                 if raw_vcs = config.get('manifest_source', nil)
                     manifest.vcs = VCSDefinition.from_raw(raw_vcs)
                 else

--- a/test/cli/test_reconfigure.rb
+++ b/test/cli/test_reconfigure.rb
@@ -1,0 +1,42 @@
+require 'autoproj/test'
+require 'autoproj/cli/main'
+require 'autoproj/cli/reconfigure'
+require 'timeout'
+
+module Autoproj
+    module CLI
+        describe Reconfigure do
+            attr_reader :ws
+            before do
+                option_name = "custom-configuration-option"
+                default_value = "option-defaultvalue"
+
+                @ws = ws_create(make_tmpdir, partial_config: true)
+            end
+            after do
+                Autoproj.verbose = false
+            end
+            describe "#reconfigure" do
+                def run_command(*args)
+                    capture_subprocess_io do
+                        ENV['AUTOPROJ_CURRENT_ROOT'] = ws.root_path.to_s
+                        in_ws do
+                            Main.start([*args,"--debug"], debug: true)
+                        end
+                    end
+                end
+
+                it "reconfigure should run interactively" do
+                    assert_raises Timeout::Error do
+                        Timeout.timeout(3) do
+                            run_command 'reconfigure'
+                        end
+                    end
+                end
+                it "reconfigure should run non interactively" do
+                    run_command 'reconfigure','--no-interactive'
+                end
+            end
+        end
+    end
+end

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -486,6 +486,7 @@ module Autoproj
                 flexmock(Autoproj::Configuration).new_instances.
                     should_receive(:source_dir).and_return(ws.root_dir)
                 assert_raises(ConfigError) do
+                    ws.config = Configuration.new(ws.root_dir)
                     ws.load_config
                 end
             end


### PR DESCRIPTION
…on the default values

Avoid the need for updating seed configurations when new configurations options are introduced to autoproj.