### PR TITLE
Fix warning of user when he tries to use an ignored package

### DIFF
--- a/lib/autoproj/cli/base.rb
+++ b/lib/autoproj/cli/base.rb
@@ -156,9 +156,18 @@ module Autoproj
                 raise CLIInvalidSelection, e.message, e.backtrace
             end
 
+            # Check whether the user selection refers to non-existant/unknown
+            # packages
+            #
+            # @param [Array<String>] user_selection List of selected packages
+            # @param [Autoproj::PackageSelection] resolved_selection The
+            #   selection of known packages
+            # @raises [CLIInvalidArguments] if no match for a package could be found
             def validate_user_selection(user_selection, resolved_selection)
                 not_matched = user_selection.find_all do |pkg_name|
-                    !resolved_selection.has_match_for?(pkg_name)
+                    !resolved_selection.has_match_for?(pkg_name) &&
+                        !(resolved_selection.ignored?(pkg_name) ||
+                          resolved_selection.excluded?(pkg_name))
                 end
                 if !not_matched.empty?
                     raise CLIInvalidArguments, "autoproj: wrong package selection on command line, cannot find a match for #{not_matched.to_a.sort.join(", ")}"

--- a/lib/autoproj/package_selection.rb
+++ b/lib/autoproj/package_selection.rb
@@ -50,6 +50,24 @@ module Autoproj
                 selection.empty?
             end
 
+            # Test if a package is in the ignore list
+            #
+            # @param [String] pkg_name Name of the package
+            # @return [Bool] true, if package is in the ignore list, false
+            # otherwise
+            def ignored?(pkg_name)
+                ignores.include?(pkg_name)
+            end
+
+            # Test if a package is in the exclusions list
+            #
+            # @param [String] pkg_name Name of the package
+            # @return [Bool] true, if package is in the exclusion list, false
+            # otherwise
+            def excluded?(pkg_name)
+                exclusions.include?(pkg_name)
+            end
+
             # Returns the source packages selected explicitely or through
             # dependencies
             #

--- a/test/cli/test_base.rb
+++ b/test/cli/test_base.rb
@@ -24,6 +24,18 @@ module Autoproj
                         end
                     end
 
+                    it "warn if an ignored package is selected" do
+                        ws_add_package_to_layout :cmake, 'pkg0'
+                        @ws.manifest.ignore_package 'pkg0'
+                        out, err = capture_subprocess_io do
+                            selection, non_resolved = @base.resolve_user_selection([])
+                            import = Autoproj::Ops::Import.new(@ws)
+                            import.import_packages(selection)
+                        end
+                        assert_match /WARN: pkg0, which was selected for pkg0, is ignored/,
+                            err, "Warning on ignored package should be reported to user. Error output was: #{err}"
+                    end
+
                     it "raises CLIInvalidSelection if a package set that depends on an excluded package is being selected" do
                         pkg_set = ws_add_package_set_to_layout 'test'
                         pkg0 = ws_define_package :cmake, 'pkg0'


### PR DESCRIPTION
Instead of complaining about finding a match at all for the package, autoproj should warn the user about an ignored (but still matched) package.


