### PR TITLE
allow managing doc dependencies through cli

### DIFF
--- a/lib/autoproj/cli/doc.rb
+++ b/lib/autoproj/cli/doc.rb
@@ -1,24 +1,11 @@
-require 'autoproj/cli/inspection_tool'
+require 'autoproj/cli/utility'
 
 module Autoproj
     module CLI
-        class Doc < InspectionTool
-            def validate_options(packages, options)
-                packages, options = super
-                if options[:no_deps_shortcut]
-                    options[:deps] = false
-                end
-                return packages, options
-            end
-
-            def run(user_selection, deps: true)
-                initialize_and_load
-                packages, _ =
-                    finalize_setup(user_selection, recursive: deps)
-                packages.each do |pkg|
-                    ws.manifest.find_autobuild_package(pkg).disable_phases('import', 'prepare', 'install')
-                end
-                Autobuild.apply(packages, "autoproj-doc", ['doc'])
+        class Doc < Utility
+            def initialize(ws = Workspace.default)
+                @utility_name = 'doc'
+                super
             end
         end
     end

--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -1,5 +1,6 @@
 require 'thor'
 require 'tty/color'
+require 'autoproj/cli/main_doc'
 require 'autoproj/cli/main_test'
 require 'autoproj/cli/main_plugin'
 require 'autoproj/cli/main_global'
@@ -183,15 +184,6 @@ module Autoproj
                 run_autoproj_cli(:status, :Status, Hash[], *packages)
             end
 
-            desc 'doc [PACKAGES]', 'generate API documentation for packages that support it'
-            option :deps, type: :boolean, default: true,
-                desc: 'control whether documentation should be generated only for the packages given on the command line, or also for their dependencies. -n is a shortcut for --no-deps'
-            option :no_deps_shortcut, hide: true, aliases: '-n', type: :boolean,
-                desc: 'provide -n for --no-deps'
-            def doc(*packages)
-                run_autoproj_cli(:doc, :Doc, Hash[], *packages)
-            end
-
             desc 'update [PACKAGES]', 'update packages'
             option :aup, default: false, hide: true, type: :boolean,
                 desc: 'behave like aup'
@@ -359,6 +351,9 @@ In this case, the default is false
 
             desc 'test', 'interface for running tests'
             subcommand 'test', MainTest
+
+            desc 'doc', 'interface for generating documentation'
+            subcommand 'doc', MainDoc
 
             desc 'show [PACKAGES]', 'show informations about package(s)'
             option :mainline, type: :string,

--- a/lib/autoproj/cli/main_doc.rb
+++ b/lib/autoproj/cli/main_doc.rb
@@ -1,0 +1,86 @@
+module Autoproj
+    module CLI
+        class MainDoc < Thor
+            namespace 'doc'
+
+            default_command 'exec'
+
+            no_commands do
+                def report(report_options = Hash.new)
+                    options = self.options.merge(parent_options)
+                    extra_options = Hash.new
+                    if Autobuild::Subprocess.transparent_mode = options[:tool]
+                        Autobuild.silent = true
+                        Autobuild.color = false
+                        report_options[:silent] = true
+                        report_options[:on_package_failures] = :exit_silent
+                        extra_options[:silent] = true
+                    end
+                    Autoproj.report(**Hash[debug: options[:debug]].merge(report_options)) do
+                        yield(extra_options)
+                    end
+                end
+            end
+
+            desc 'enable [PACKAGES]', 'enable docs for the given packages (or for all packages if none are given)'
+            option :deps, type: :boolean, default: false,
+                desc: 'controls whether the dependencies of the packages given on the command line should be enabled as well (the default is not)'
+            def enable(*packages)
+                require 'autoproj/cli/doc'
+                report(silent: true) do
+                    cli = Doc.new
+                    args = cli.validate_options(packages, options)
+                    cli.enable(*args)
+                end
+            end
+
+            desc 'disable [PACKAGES]', 'disable docs for the given packages (or for all packages if none are given)'
+            option :deps, type: :boolean, default: false,
+                desc: 'controls whether the dependencies of the packages given on the command line should be disabled as well (the default is not)'
+            def disable(*packages)
+                require 'autoproj/cli/doc'
+                report(silent: true) do
+                    cli = Doc.new
+                    args = cli.validate_options(packages, options)
+                    cli.disable(*args)
+                end
+            end
+
+            desc 'list [PACKAGES]', 'show doc enable/disable status for the given packages (or all packages if none are given)'
+            option :deps, type: :boolean, default: true,
+                desc: 'controls whether the dependencies of the packages given on the command line should be disabled as well (the default is not)'
+            def list(*packages)
+                require 'autoproj/cli/doc'
+                report(silent: true) do
+                    cli = Doc.new
+                    args = cli.validate_options(packages, options)
+                    cli.list(*args)
+                end
+            end
+
+            desc 'exec [PACKAGES]', 'generate documentation for the given packages, or all if no packages are given on the command line'
+            option :deps, type: :boolean, default: false,
+                desc: 'controls whether to generate documentation of the dependencies of the packages given on the command line (the default is not)'
+            option :no_deps_shortcut, hide: true, aliases: '-n', type: :boolean,
+                desc: 'provide -n for --no-deps'
+            option :parallel, aliases: :p, type: :numeric,
+                desc: 'maximum number of parallel jobs'
+            option :tool, type: :boolean, default: false,
+                desc: "run in tool mode, which do not redirect the subcommand's outputs"
+            option :color, type: :boolean, default: TTY::Color.color?,
+                desc: 'enables or disables colored display (enabled by default if the terminal supports it)'
+            option :progress, type: :boolean, default: TTY::Color.color?,
+                desc: 'enables or disables progress display (enabled by default if the terminal supports it)'
+            def exec(*packages)
+                require 'autoproj/cli/doc'
+                options = self.options.merge(parent_options)
+                report do |extra_options|
+                    cli = Doc.new
+                    options.delete(:tool)
+                    args = cli.validate_options(packages, options.merge(extra_options))
+                    cli.run(*args)
+                end
+            end
+        end
+    end
+end

--- a/lib/autoproj/cli/test.rb
+++ b/lib/autoproj/cli/test.rb
@@ -1,93 +1,11 @@
-require 'autoproj/cli/inspection_tool'
+require 'autoproj/cli/utility'
 
 module Autoproj
     module CLI
-        class Test < InspectionTool
-            def enable(user_selection, options = {})
-                if user_selection.empty?
-                    ws.load_config
-                    ws.config.utility_enable_all('test')
-                else
-                    initialize_and_load
-                    selection, = finalize_setup(
-                        user_selection,
-                        recursive: options[:deps],
-                        non_imported_packages: :return
-                    )
-                    ws.config.utility_enable('test', *selection)
-                end
-                ws.config.save
-            end
-
-            def disable(user_selection, options = {})
-                if user_selection.empty?
-                    ws.load_config
-                    ws.config.utility_disable_all('test')
-                else
-                    initialize_and_load
-                    selection, = finalize_setup(
-                        user_selection,
-                        recursive: options[:deps],
-                        non_imported_packages: :return
-                    )
-                    ws.config.utility_disable('test', *selection)
-                end
-                ws.config.save
-            end
-
-            def list(user_selection, options = {})
-                initialize_and_load
-                resolved_selection, = finalize_setup(
-                    user_selection,
-                    recursive: options[:deps],
-                    non_imported_packages: :return
-                )
-
-                lines = []
-                resolved_selection.each do |pkg_name|
-                    pkg = ws.manifest.find_package_definition(pkg_name).autobuild
-                    lines << [
-                        pkg.name,
-                        pkg.test_utility.enabled?,
-                        pkg.test_utility.available?
-                    ]
-                end
-                lines = lines.sort_by { |name, _| name }
-                w     = lines.map { |name, _| name.length }.max
-                out_format = "%-#{w}s %-7s %-9s"
-                puts format(out_format, 'Package Name', 'Enabled', 'Available')
-                lines.each do |name, enabled, available|
-                    puts(format(out_format, name, (!!enabled).to_s, (!!available).to_s))
-                end
-            end
-
-            def run(user_selection, options = {})
-                options[:parallel] ||= ws.config.parallel_build_level
-                initialize_and_load
-
-                packages, _, resolved_selection = finalize_setup(
-                    user_selection,
-                    recursive: user_selection.empty? || options[:deps]
-                )
-
-                validate_user_selection(user_selection, resolved_selection)
-                if packages.empty?
-                    raise CLIInvalidArguments, "autoproj: the provided package "\
-                        "is not selected for build"
-                end
-
-                packages.each do |pkg|
-                    ws.manifest.find_autobuild_package(pkg).disable_phases(
-                        'import', 'prepare', 'install'
-                    )
-                end
-
-                Autobuild.apply(
-                    packages,
-                    'autoproj-test',
-                    ['test'],
-                    parallel: options[:parallel]
-                )
+        class Test < Utility
+            def initialize(ws = Workspace.default)
+                @utility_name = 'test'
+                super
             end
         end
     end

--- a/lib/autoproj/cli/utility.rb
+++ b/lib/autoproj/cli/utility.rb
@@ -1,0 +1,95 @@
+require 'autoproj/cli/inspection_tool'
+
+module Autoproj
+    module CLI
+        class Utility < InspectionTool
+            attr_reader :utility_name
+            def enable(user_selection, options = {})
+                if user_selection.empty?
+                    ws.load_config
+                    ws.config.utility_enable_all(utility_name)
+                else
+                    initialize_and_load
+                    selection, = finalize_setup(
+                        user_selection,
+                        recursive: options[:deps],
+                        non_imported_packages: :return
+                    )
+                    ws.config.utility_enable(utility_name, *selection)
+                end
+                ws.config.save
+            end
+
+            def disable(user_selection, options = {})
+                if user_selection.empty?
+                    ws.load_config
+                    ws.config.utility_disable_all(utility_name)
+                else
+                    initialize_and_load
+                    selection, = finalize_setup(
+                        user_selection,
+                        recursive: options[:deps],
+                        non_imported_packages: :return
+                    )
+                    ws.config.utility_disable(utility_name, *selection)
+                end
+                ws.config.save
+            end
+
+            def list(user_selection, options = {})
+                initialize_and_load
+                resolved_selection, = finalize_setup(
+                    user_selection,
+                    recursive: options[:deps],
+                    non_imported_packages: :return
+                )
+
+                lines = []
+                resolved_selection.each do |pkg_name|
+                    pkg = ws.manifest.find_package_definition(pkg_name).autobuild
+                    lines << [
+                        pkg.name,
+                        pkg.send("#{utility_name}_utility").enabled?,
+                        pkg.send("#{utility_name}_utility").available?
+                    ]
+                end
+                lines = lines.sort_by { |name, _| name }
+                w     = lines.map { |name, _| name.length }.max
+                out_format = "%-#{w}s %-7s %-9s"
+                puts format(out_format, 'Package Name', 'Enabled', 'Available')
+                lines.each do |name, enabled, available|
+                    puts(format(out_format, name, (!!enabled).to_s, (!!available).to_s))
+                end
+            end
+
+            def run(user_selection, options = {})
+                options[:parallel] ||= ws.config.parallel_build_level
+                initialize_and_load
+
+                packages, _, resolved_selection = finalize_setup(
+                    user_selection,
+                    recursive: user_selection.empty? || options[:deps]
+                )
+
+                validate_user_selection(user_selection, resolved_selection)
+                if packages.empty?
+                    raise CLIInvalidArguments, "autoproj: the provided package "\
+                        "is not selected for build"
+                end
+
+                packages.each do |pkg|
+                    ws.manifest.find_autobuild_package(pkg).disable_phases(
+                        'import', 'prepare', 'install'
+                    )
+                end
+
+                Autobuild.apply(
+                    packages,
+                    "autoproj-#{utility_name}",
+                    [utility_name],
+                    parallel: options[:parallel]
+                )
+            end
+        end
+    end
+end


### PR DESCRIPTION
@doudou How would feel about making doc_depend off by default (to be consistent with test_depend)?