### PR TITLE
don't expect any initialization to be already done in run_bundler

### DIFF
--- a/test/package_managers/test_bundler_manager.rb
+++ b/test/package_managers/test_bundler_manager.rb
@@ -1,0 +1,20 @@
+require 'autoproj/test'
+
+module Autoproj
+    module PackageManagers
+        describe BundlerManager do
+            describe ".run_bundler" do
+                it "defaults to the workspace's shim if program['bundler'] is not initialized" do
+                    Autobuild.programs['bundle'] = nil
+                    ws = flexmock(dot_autoproj_dir: '/some/path')
+                    ws.should_receive(:run)
+                      .with(any, any, '/some/path/bin/bundle', 'some', 'program', Hash, Proc)
+                      .once
+                    BundlerManager.run_bundler(ws, 'some', 'program',
+                                               gem_home: '/gem/home',
+                                               gemfile: '/gem/path/Gemfile')
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
run_bundler uses `Autobuild.tool('bundle')` as program. This is
in turn expects initialize_environment to have been called, which
fails in early codepaths as e.g. the one that deals with plugins.

Fallback instead to our `bundle` shim in .autoproj if no override
has been set.