### PR TITLE
fix utility-related dependencies not being installed on first checkout

### DIFF
--- a/lib/autoproj/autobuild_extensions/dsl.rb
+++ b/lib/autoproj/autobuild_extensions/dsl.rb
@@ -198,14 +198,16 @@ def common_make_based_package_setup(pkg)
     end
 
     unless pkg.test_utility.has_task?
-        unless pkg.test_utility.source_dir
-            test_dir = File.join(pkg.srcdir, 'test')
-            if File.directory?(test_dir)
-                pkg.test_utility.source_dir = File.join(pkg.builddir, 'test', 'results')
+        pkg.post_import do
+            unless pkg.test_utility.source_dir
+                test_dir = File.join(pkg.srcdir, 'test')
+                if File.directory?(test_dir)
+                    pkg.test_utility.source_dir = File.join(pkg.builddir, 'test', 'results')
+                end
             end
-        end
 
-        pkg.with_tests if pkg.test_utility.source_dir
+            pkg.with_tests if pkg.test_utility.source_dir
+        end
     end
 end
 
@@ -284,15 +286,17 @@ def ruby_package(name, workspace: Autoproj.workspace)
         pkg.with_doc if !pkg.has_doc? && pkg.rake_doc_task
 
         unless pkg.test_utility.has_task?
-            unless pkg.test_utility.source_dir
-                test_dir = File.join(pkg.srcdir, 'test')
-                if File.directory?(test_dir)
-                    pkg.test_utility.source_dir = File.join(pkg.srcdir, '.test-results')
-                    FileUtils.mkdir_p pkg.test_utility.source_dir
+            pkg.post_import do
+                unless pkg.test_utility.source_dir
+                    test_dir = File.join(pkg.srcdir, 'test')
+                    if File.directory?(test_dir)
+                        pkg.test_utility.source_dir = File.join(pkg.srcdir, '.test-results')
+                        FileUtils.mkdir_p pkg.test_utility.source_dir
+                    end
                 end
-            end
 
-            pkg.with_tests if pkg.test_utility.source_dir
+                pkg.with_tests if pkg.test_utility.source_dir
+            end
         end
 
         yield(pkg) if block_given?

--- a/lib/autoproj/base.rb
+++ b/lib/autoproj/base.rb
@@ -6,7 +6,7 @@ module Autoproj
         else
             ArgumentError
         end
-            
+
     # Yields, and if the given block raises a ConfigError with no file assigned,
     # add that file to both the object and the exception message
     def self.in_file(file, exception_t = ConfigError)
@@ -28,18 +28,31 @@ module Autoproj
         attr_reader :post_import_blocks
     end
 
+    # Enumerate the post-import blocks registered for the given package
+    #
+    # @param [PackageDefinition] pkg
+    # @see post_import
     def self.each_post_import_block(pkg, &block)
+        # We use Autobuild packages as keys
+        pkg = pkg.autobuild if pkg.respond_to?(:autobuild)
+
         @post_import_blocks[nil].each(&block)
-        if @post_import_blocks.has_key?(pkg)
-            @post_import_blocks[pkg].each(&block)
-        end
+        @post_import_blocks[pkg]&.each(&block)
     end
 
+    # Register a block that should be called after a set of package(s) have
+    # been imported
+    #
+    # @overload post_import(&block) register the block for all packages
+    # @overload post_import(*packages, &block)
+    #   @param [Array<Autobuild::Package,PackageDefinition>] packages
     def self.post_import(*packages, &block)
         if packages.empty?
             @post_import_blocks[nil] << block
         else
             packages.each do |pkg|
+                # We use Autobuild packages as keys
+                pkg = pkg.autobuild if pkg.respond_to?(:autobuild)
                 @post_import_blocks[pkg] << block
             end
         end

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -1020,23 +1020,14 @@ module Autoproj
             if manifest
                 pkg.autobuild.description = manifest
             else
-                Autoproj.warn "#{package.name} from #{package_set.name} does not have a manifest"
+                Autoproj.warn "#{package.name} from #{package_set.name} "\
+                              "does not have a manifest"
             end
 
-            manifest = pkg.autobuild.description
-            manifest.each_dependency(pkg.modes) do |name, is_optional|
-                begin
-                    if is_optional
-                        package.optional_dependency name
-                    else
-                        package.depends_on name
-                    end
-                rescue ConfigError => e
-                    raise ConfigError.new(manifest_path),
-                        "manifest #{manifest_path} of #{package.name} from #{package_set.name} lists '#{name}' as dependency, but it is neither a normal package nor an osdeps package. osdeps reports: #{e.message}", e.backtrace
-                end
-            end
-            manifest
+            pkg.apply_dependencies_from_manifest
+            # #description is initialized with a null package manifest
+            # return it even if we haven't overriden it
+            pkg.autobuild.description
         end
 
         def load_all_available_package_manifests

--- a/lib/autoproj/package_definition.rb
+++ b/lib/autoproj/package_definition.rb
@@ -79,5 +79,24 @@ module Autoproj
         def depends_on(pkg)
             autobuild.depends_on(pkg.autobuild)
         end
+
+        def apply_dependencies_from_manifest
+            manifest = autobuild.description
+            manifest.each_dependency(modes) do |name, is_optional|
+                begin
+                    if is_optional
+                        autobuild.optional_dependency name
+                    else
+                        autobuild.depends_on name
+                    end
+                rescue ConfigError => e
+                    raise ConfigError.new(manifest.path),
+                          "manifest #{manifest.path} of #{self.name} from "\
+                          "#{package_set.name} lists '#{name}' as dependency, "\
+                          'but it is neither a normal package nor an osdeps '\
+                          "package. osdeps reports: #{e.message}", e.backtrace
+                end
+            end
+        end
     end
 end

--- a/lib/autoproj/package_manifest.rb
+++ b/lib/autoproj/package_manifest.rb
@@ -31,7 +31,7 @@ module Autoproj
         # @return [PackageManifest]
         # @see load
         def self.parse(package, contents, path: '<loaded from string>', loader_class: Loader)
-            manifest = PackageManifest.new(package)
+            manifest = PackageManifest.new(package, path)
             loader = loader_class.new(path, manifest)
             begin
                 REXML::Document.parse_stream(contents, loader)
@@ -46,6 +46,7 @@ module Autoproj
 
         # The Autobuild::Package instance this manifest applies on
         attr_reader :package
+        attr_reader :path
         attr_accessor :description
         attr_accessor :brief_description
         attr_reader :dependencies
@@ -79,8 +80,9 @@ module Autoproj
                 "no documentation available for package '#{package.name}' in its manifest.xml file"
         end
 
-        def initialize(package, null: false)
+        def initialize(package, path = nil, null: false)
             @package = package
+            @path = path
             @dependencies = []
             @authors = []
             @maintainers = []


### PR DESCRIPTION
Regression test: https://github.com/rock-core/build_tests-test/pull/3 (packages https://github.com/rock-core/rock.build-tests-package_set/pull/5)

The utility enabled? flag is dependent on the utility availability,
which in turn is decided by testing for the presence of a test/ folder
for e.g. cmake packages.

The first mistake was that this test was done in the main context,
not a post_import block.

Then, post import blocks were called after the dependencies from
the manifest are applied to the package. Any change of utility
within the post import block would therefore not be taken into
consideration when interpreting the manifest file.