### PR TITLE
bundler: allow setting build flags from Autoproj configuration

### DIFF
--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -88,8 +88,79 @@ module Autoproj
                     end
                 end
 
-                if bundle_rubylib = discover_bundle_rubylib(silent_errors: true)
+                apply_build_config(prefix_gems)
+
+                if (bundle_rubylib = discover_bundle_rubylib(silent_errors: true))
                     update_env_rubylib(bundle_rubylib, system_rubylib)
+                end
+            end
+
+            # Enumerate the per-gem build configurations
+            def per_gem_build_config
+                ws.config.get('bundler.build', {})
+            end
+
+            # Set the build configuration for the given gem
+            #
+            # This is meant to be used from the Autoproj configuration files,
+            # e.g. overrides.rb or package configuration
+            def self.configure_build_for(gem_name, build_config, ws: Autoproj.workspace)
+                c = ws.config.get('bundler.build', {})
+                c[gem_name] = build_config
+                ws.config.set('bundler.build', c)
+            end
+
+            # Removes build configuration flags for the given gem
+            #
+            # This is meant to be used from the Autoproj configuration files,
+            # e.g. overrides.rb or package configuration
+            def self.remove_build_configuration_for(gem_name, ws: Autoproj.workspace)
+                c = ws.config.get('bundler.build', {})
+                c.delete(gem_name)
+                ws.config.set('bundler.build', c)
+            end
+
+            # @api private
+            #
+            # Apply configured per-gem build configuration options
+            # 
+            # @param [String] root_dir the path of the Bundler workspace root
+            #   directory. In Autoproj workspaces, this is {prefix_dir}/gems by
+            #   default
+            def apply_build_config(root_dir)
+                current_config_path = File.join(root_dir, ".bundle", "config")
+                current_config =
+                    if File.file?(current_config_path)
+                        File.readlines(current_config_path)
+                    else
+                        []
+                    end
+
+                build_config = {}
+                per_gem_build_config.each do |name, conf|
+                    build_config[name.upcase] = conf
+                end
+
+                new_config = current_config.map do |line|
+                    next(line) unless (m = line.match(/BUNDLE_BUILD__(.*): "(.*)"$/))
+                    next unless (desired_config = build_config.delete(m[1]))
+
+                    if m[2] != desired_config
+                        "BUNDLE_BUILD__#{m[1]}: \"#{desired_config}\""
+                    else
+                        line
+                    end
+                end.compact
+
+                build_config.each do |name, config|
+                    new_config << "BUNDLE_BUILD__#{name}: \"#{config}\""
+                end
+
+                if new_config != current_config
+                    FileUtils.mkdir_p File.dirname(current_config_path)
+                    File.open(current_config_path, 'w') do |io|
+                        io.write new_config.join
+                    end
                 end
             end
 

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -316,6 +316,9 @@ gem 'autobuild', path: '#{autobuild_dir}'
             ws.config.set 'gems_install_path', File.join(dir, 'gems')
             ws.prefix_dir = make_tmpdir
             ws.config.save
+
+            # Make a valid (albeit empty) Gemfile
+            File.open(File.join(ws.dot_autoproj_dir, 'Gemfile'), 'w').close
             ws
         end
 

--- a/test/package_managers/test_bundler_manager.rb
+++ b/test/package_managers/test_bundler_manager.rb
@@ -15,6 +15,51 @@ module Autoproj
                                                gemfile: '/gem/path/Gemfile')
                 end
             end
+
+            describe "#initialize_environment" do
+                before do
+                    @ws = ws_create
+                    @bundler_manager = BundlerManager.new(@ws)
+                end
+
+                def run_bundler_config
+                    `BUNDLE_GEMFILE=#{@ws.prefix_dir}/gems/Gemfile bundle config`.split("\n")
+                end
+
+                it "adds build configurations" do
+                    BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
+                    @bundler_manager.initialize_environment
+
+                    lines = run_bundler_config.each_cons(2).find do |a, b|
+                        a =~ /build.testgem/
+                    end
+                    assert_match(/Set for your local app.*: "--some=config"/,
+                                 lines[1])
+                end
+                it "updates existing build configurations" do
+                    BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
+                    @bundler_manager.initialize_environment
+                    BundlerManager.configure_build_for('testgem', '--some=other', ws: @ws)
+                    @bundler_manager.initialize_environment
+
+                    lines = run_bundler_config.each_cons(2).find do |a, b|
+                        a =~ /build.testgem/
+                    end
+                    assert_match(/Set for your local app.*: "--some=other"/,
+                                 lines[1])
+                end
+                it "removes obsolete build configurations" do
+                    BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
+                    @bundler_manager.initialize_environment
+                    BundlerManager.remove_build_configuration_for('testgem', ws: @ws)
+                    @bundler_manager.initialize_environment
+
+                    lines = run_bundler_config.each_cons(2).find do |a, b|
+                        a =~ /build.testgem/
+                    end
+                    refute lines
+                end
+            end
         end
     end
 end


### PR DESCRIPTION
Bundler allows configuring per-gem build flags, to let the gem
that have C extensions find their dependencies.

This commit adds the ability to set these flags within an
Autoproj workspace, from e.g. within overrides.rb:

~~~ruby
Autoproj::PackageManagers::BundlerManager
.configure_build_for(
  Autoproj.workspace,
  'gemname', '--some=other')
~~~