### PR TITLE
generate a build report file on update as well

### DIFF
--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -201,7 +201,7 @@ module Autoproj
                     setup_update_from(from)
                 end
 
-                ops = Autoproj::Ops::Import.new(ws)
+                ops = Autoproj::Ops::Import.new(ws, report_path: ws.import_report_path)
                 source_packages, osdep_packages =
                         ops.import_packages(selected_packages,
                                         checkout_only: checkout_only,

--- a/lib/autoproj/ops/build.rb
+++ b/lib/autoproj/ops/build.rb
@@ -92,11 +92,11 @@ module Autoproj
                 begin
                     Autobuild.apply(all_enabled_packages, "autoproj-build", ['build'], options)
                 ensure
-                    build_report(all_enabled_packages) if @report_path
+                    create_report(all_enabled_packages) if @report_path
                 end
             end
 
-            def build_report(package_list)
+            def create_report(package_list)
                 FileUtils.mkdir_p File.dirname(@report_path)
 
                 packages = package_list.map do |pkg_name|
@@ -114,13 +114,13 @@ module Autoproj
                     }
                 end
 
-                build_report = JSON.pretty_generate({
+                report = JSON.pretty_generate({
                     build_report: {
                         timestamp: Time.now,
                         packages: packages
                     }
                 })
-                IO.write(@report_path, build_report)
+                IO.write(@report_path, report)
             end
         end
     end

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -243,6 +243,15 @@ module Autoproj
             File.join(config_dir, OVERRIDES_DIR)
         end
 
+        IMPORT_REPORT_BASENAME = "import_report.json"
+
+        # The full path to the update report
+        #
+        # @return [String]
+        def import_report_path
+            File.join(log_dir, IMPORT_REPORT_BASENAME)
+        end
+
         BUILD_REPORT_BASENAME = "build_report.json"
 
         # The full path to the build report

--- a/test/ops/test_build.rb
+++ b/test/ops/test_build.rb
@@ -38,7 +38,7 @@ module Autoproj
             end
 
             it "works even if given no packages to work on" do
-                @build.build_report([])
+                @build.create_report([])
                 json = read_report
                 assert_equal Hash['build_report' => {
                                     'timestamp' => Time.mktime(1970,1,1).to_s,
@@ -47,7 +47,7 @@ module Autoproj
             end
 
             it "works with just one successful package" do
-                @build.build_report(['pkg1'])
+                @build.create_report(['pkg1'])
                 json = read_report
                 assert_equal Hash['build_report' => {
                                     'timestamp' => Time.mktime(1970,1,1).to_s,
@@ -56,7 +56,7 @@ module Autoproj
             end
 
             it "works with just one failed package" do
-                @build.build_report(['pkg2'])
+                @build.create_report(['pkg2'])
                 json = read_report
                 assert_equal Hash['build_report' => {
                                     'timestamp' => Time.mktime(1970,1,1).to_s,
@@ -66,7 +66,7 @@ module Autoproj
 
 
             it "exports the status of several given packages" do
-                @build.build_report(['pkg1','pkg2', 'pkg3'])
+                @build.create_report(['pkg1','pkg2', 'pkg3'])
                 json = read_report
                 assert_equal Hash['build_report' => {
                     'timestamp' => Time.mktime(1970,1,1).to_s,

--- a/test/ops/test_import.rb
+++ b/test/ops/test_import.rb
@@ -58,6 +58,35 @@ module Autoproj
                     ops.import_packages(@selection)
                 end
 
+                it "exports a report for the processed packages" do
+                    tmpdir = make_tmpdir
+                    report_path = File.join(tmpdir, 'report.json')
+                    ops = Import.new(ws, report_path: report_path)
+                    flexmock(ops).should_receive(:import_selected_packages).
+                        and_return([[@pkg1], []])
+
+                    ws.manifest.should_receive(:load_package_manifest)
+                    ops.import_packages(@selection) # to shut up warnings
+                    json = JSON.load(File.read(report_path))
+                    assert_equal ['1'], json['import_report']['packages'].map { |h| h['name'] }
+                end
+
+                it "exports a report on failure" do
+                    tmpdir = make_tmpdir
+                    report_path = File.join(tmpdir, 'report.json')
+                    ops = Import.new(ws, report_path: report_path)
+                    e = Class.new(RuntimeError)
+                    flexmock(ops).should_receive(:import_selected_packages).
+                        and_return([[@pkg1], [e]])
+
+                    ws.manifest.should_receive(:load_package_manifest)
+                    assert_raises(e) do
+                        ops.import_packages(@selection) # to shut up warnings
+                    end
+                    json = JSON.load(File.read(report_path))
+                    assert_equal ['1'], json['import_report']['packages'].map { |h| h['name'] }
+                end
+
                 describe "auto_exclude: true" do
                     it "excludes packages that have failed to load" do
                         flexmock(ops).should_receive(:import_selected_packages).
@@ -78,6 +107,113 @@ module Autoproj
 
                     flexmock(ops).should_receive(:install_internal_dependencies_for).with(@pkg1).once
                     ops.import_packages(@selection)
+                end
+            end
+
+            describe "#create_report" do
+                before do
+                    @ws = ws_create
+                    @ops = Import.new(ws, report_path: @ws.import_report_path)
+                    @pkg1 = ws_define_package :cmake, 'pkg1'
+                    @pkg2 = ws_define_package :cmake, 'pkg2'
+                    @pkg3 = ws_define_package :cmake, 'pkg3'
+
+                    @pkg1object = ws.manifest.find_autobuild_package('pkg1')
+                    @pkg2object = ws.manifest.find_autobuild_package('pkg2')
+                    @pkg3object = ws.manifest.find_autobuild_package('pkg3')
+
+                    set_success_flags(@pkg1object)
+                    set_failed_flags(@pkg2object)
+                    set_failed_flags(@pkg3object)
+
+                    flexmock(Time).should_receive('now').and_return(Time.mktime(1970,1,1))
+                    flexmock(@pkg1object, prepare_invoked?: true)
+                    flexmock(@pkg1object).should_receive(import_invoked?: true)
+                    flexmock(@pkg1object).should_receive(build_invoked?: true)
+
+                end
+
+                it "works even if given no packages to work on" do
+                    @ops.create_report([])
+                    json = read_report
+                    assert_equal Hash['import_report' => {
+                                        'timestamp' => Time.mktime(1970,1,1).to_s,
+                                        'packages' => []
+                                    }], json
+                end
+
+                it "works with just one successful package" do
+                    @ops.create_report(['pkg1'])
+                    json = read_report
+                    assert_equal Hash['import_report' => {
+                                        'timestamp' => Time.mktime(1970,1,1).to_s,
+                                        'packages' => [expected_successful_package('pkg1')]
+                                    }], json
+                end
+
+                it "works with just one failed package" do
+                    @ops.create_report(['pkg2'])
+                    json = read_report
+                    assert_equal Hash['import_report' => {
+                                        'timestamp' => Time.mktime(1970,1,1).to_s,
+                                        'packages' => [expected_failed_package('pkg2')]
+                                    }], json
+                end
+
+
+                it "exports the status of several given packages" do
+                    @ops.create_report(['pkg1','pkg2', 'pkg3'])
+                    json = read_report
+                    assert_equal Hash['import_report' => {
+                        'timestamp' => Time.mktime(1970,1,1).to_s,
+                        'packages' => [ expected_successful_package('pkg1'),
+                                        expected_failed_package('pkg2'),
+                                        expected_failed_package('pkg3')
+                                      ]
+                        }], json
+                end
+
+                def read_report
+                    data = File.read(@ws.import_report_path)
+                    JSON.parse(data)
+                end
+
+                def set_success_flags(package)
+                    package.instance_variable_set(:@prepared, true)
+                    package.instance_variable_set(:@imported, true)
+                    package.instance_variable_set(:@built, true)
+                    package.instance_variable_set(:@failed, nil)
+                end
+
+                def set_failed_flags(package)
+                    package.instance_variable_set(:@prepared, false)
+                    package.instance_variable_set(:@imported, false)
+                    package.instance_variable_set(:@built, false)
+                    package.instance_variable_set(:@failed, true)
+                end
+
+                def expected_successful_package(pkg_name)
+                    Hash[
+                     'name' => pkg_name,
+                     'import_invoked' => true,
+                     'prepare_invoked' => true,
+                     'build_invoked' => true,
+                     'failed' => nil,
+                     'imported'=> true,
+                     'prepared'=> true,
+                     'built'=> true]
+                end
+
+                def expected_failed_package(pkg_name)
+                    Hash[
+                     'name' => pkg_name,
+                     'import_invoked' => false,
+                     'prepare_invoked' => false,
+                     'build_invoked' => false,
+                     'failed' => true,
+                     'imported'=> false,
+                     'prepared'=> false,
+                     'built'=> false]
                 end
             end
 


### PR DESCRIPTION
The build report was created only on build so far, which means that
nothing would be reported if update fails (!)

Generate one on update too.