### PR TITLE
bundler: apply per-gem configuration right before running install

### DIFF
--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -88,15 +88,13 @@ module Autoproj
                     end
                 end
 
-                apply_build_config(prefix_gems)
-
                 if (bundle_rubylib = discover_bundle_rubylib(silent_errors: true))
                     update_env_rubylib(bundle_rubylib, system_rubylib)
                 end
             end
 
             # Enumerate the per-gem build configurations
-            def per_gem_build_config
+            def self.per_gem_build_config(ws)
                 ws.config.get('bundler.build', {})
             end
 
@@ -123,11 +121,12 @@ module Autoproj
             # @api private
             #
             # Apply configured per-gem build configuration options
-            # 
-            # @param [String] root_dir the path of the Bundler workspace root
-            #   directory. In Autoproj workspaces, this is {prefix_dir}/gems by
-            #   default
-            def apply_build_config(root_dir)
+            #
+            # @param [Workspace] ws the workspace whose bundler configuration
+            #   should be updated
+            # @return [void]
+            def self.apply_build_config(ws)
+                root_dir = File.join(ws.prefix_dir, 'gems')
                 current_config_path = File.join(root_dir, ".bundle", "config")
                 current_config =
                     if File.file?(current_config_path)
@@ -137,7 +136,7 @@ module Autoproj
                     end
 
                 build_config = {}
-                per_gem_build_config.each do |name, conf|
+                per_gem_build_config(ws).each do |name, conf|
                     build_config[name.upcase] = conf
                 end
 
@@ -253,6 +252,8 @@ module Autoproj
                 if binstubs
                     options << "--binstubs" << binstubs
                 end
+
+                apply_build_config(ws)
 
                 connections = Set.new
                 run_bundler(ws, 'install', *options, gem_home: gem_home, gemfile: gemfile) do |line|

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -98,6 +98,16 @@ module Autoproj
                 ws.config.get('bundler.build', {})
             end
 
+            # Add new build configuration arguments for a given gem
+            #
+            # This is meant to be used from the Autoproj configuration files,
+            # e.g. overrides.rb or package configuration
+            def self.add_build_configuration_for(gem_name, build_config, ws: Autoproj.workspace)
+                c = ws.config.get('bundler.build', {})
+                c[gem_name] = [c[gem_name], build_config].compact.join(" ")
+                ws.config.set('bundler.build', c)
+            end
+
             # Set the build configuration for the given gem
             #
             # This is meant to be used from the Autoproj configuration files,

--- a/test/package_managers/test_bundler_manager.rb
+++ b/test/package_managers/test_bundler_manager.rb
@@ -60,6 +60,18 @@ module Autoproj
                     end
                     refute lines
                 end
+                it "appends to existing build configuration with add_build_configuration_for" do
+                    BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
+                    BundlerManager.apply_build_config(@ws)
+                    BundlerManager.add_build_configuration_for('testgem', '--some=other', ws: @ws)
+                    BundlerManager.apply_build_config(@ws)
+
+                    lines = run_bundler_config.each_cons(2).find do |a, b|
+                        a =~ /build.testgem/
+                    end
+                    assert_match(/Set for your local app.*: "--some=config --some=other"/,
+                                 lines[1])
+                end
             end
         end
     end

--- a/test/package_managers/test_bundler_manager.rb
+++ b/test/package_managers/test_bundler_manager.rb
@@ -16,10 +16,11 @@ module Autoproj
                 end
             end
 
-            describe "#initialize_environment" do
+            describe ".apply_build_config" do
                 before do
                     @ws = ws_create
                     @bundler_manager = BundlerManager.new(@ws)
+                    @bundler_manager.initialize_environment
                 end
 
                 def run_bundler_config
@@ -28,7 +29,7 @@ module Autoproj
 
                 it "adds build configurations" do
                     BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
-                    @bundler_manager.initialize_environment
+                    BundlerManager.apply_build_config(@ws)
 
                     lines = run_bundler_config.each_cons(2).find do |a, b|
                         a =~ /build.testgem/
@@ -38,9 +39,9 @@ module Autoproj
                 end
                 it "updates existing build configurations" do
                     BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
-                    @bundler_manager.initialize_environment
+                    BundlerManager.apply_build_config(@ws)
                     BundlerManager.configure_build_for('testgem', '--some=other', ws: @ws)
-                    @bundler_manager.initialize_environment
+                    BundlerManager.apply_build_config(@ws)
 
                     lines = run_bundler_config.each_cons(2).find do |a, b|
                         a =~ /build.testgem/
@@ -50,9 +51,9 @@ module Autoproj
                 end
                 it "removes obsolete build configurations" do
                     BundlerManager.configure_build_for('testgem', '--some=config', ws: @ws)
-                    @bundler_manager.initialize_environment
+                    BundlerManager.apply_build_config(@ws)
                     BundlerManager.remove_build_configuration_for('testgem', ws: @ws)
-                    @bundler_manager.initialize_environment
+                    BundlerManager.apply_build_config(@ws)
 
                     lines = run_bundler_config.each_cons(2).find do |a, b|
                         a =~ /build.testgem/


### PR DESCRIPTION
Associated build test: https://github.com/rock-core/rock.build-tests-buildconf/pull/3

Doing it in initialize_environment is actually pretty limited:
the only place where code gets run before initialize_environment
is autoproj/init.rb

Move updating the bundler config right before it is needed,
that is in run_bundler_install