### PR TITLE
cli: create 'autoproj test default'

### DIFF
--- a/lib/autoproj/cli/main_test.rb
+++ b/lib/autoproj/cli/main_test.rb
@@ -22,6 +22,21 @@ module Autoproj
                 end
             end
 
+            desc 'default [on|off]', 'set whether tests are enabled or disabled by default, without touching existing settings'
+            def default(on_or_off)
+                require 'autoproj/cli/test'
+                report(silent: true) do
+                    cli = Test.new
+                    args = cli.validate_options([], options)
+                    enabled = case on_or_off
+                              when 'on' then true
+                              when 'off' then false
+                              else raise ArgumentError, "expected 'on' or 'off'"
+                              end
+                    cli.default(enabled)
+                end
+            end
+
             desc 'enable [PACKAGES]', 'enable tests for the given packages (or for all packages if none are given)'
             option :deps, type: :boolean, default: false,
                 desc: 'controls whether the dependencies of the packages given on the command line should be enabled as well (the default is not)'

--- a/lib/autoproj/cli/utility.rb
+++ b/lib/autoproj/cli/utility.rb
@@ -4,6 +4,12 @@ module Autoproj
     module CLI
         class Utility < InspectionTool
             attr_reader :utility_name
+            def default(enabled)
+                ws.load_config
+                ws.config.utility_default(utility_name, enabled)
+                ws.config.save
+            end
+
             def enable(user_selection, options = {})
                 if user_selection.empty?
                     ws.load_config

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -506,6 +506,19 @@ module Autoproj
             end
         end
 
+        # Set the given utility to enabled by default
+        #
+        # Unlike {#utility_enable_all} and {#utility_disable_all}, it does
+        # not touch existing exclusions
+        #
+        # @param [String] utility the utility name (e.g. 'doc' or 'test')
+        # @param [Boolean] enabled whether the utility will be enabled (true) or
+        #   disabled (false)
+        # @return [void]
+        def utility_default(utility, enabled)
+            set("#{utility_key(utility)}_default", enabled ? true : false)
+        end
+
         # Enables a utility for all packages
         #
         # This both sets the default value for all packages and resets all


### PR DESCRIPTION
Unlike 'enable' or 'disable' without arguments, it only switches
the default without touching the existing exclusions