### PR TITLE
cli: make sure Thor exit(1) on bad command

### DIFF
--- a/lib/autoproj/cli/main.rb
+++ b/lib/autoproj/cli/main.rb
@@ -38,6 +38,10 @@ module Autoproj
             stop_on_unknown_option! :exec
             check_unknown_options!  except: :exec
 
+            def self.exit_on_failure?
+                true
+            end
+
             class << self
                 # @api private
                 #


### PR DESCRIPTION
Thor.start exit(0) by default on command-line error (!)