### PR TITLE
build reports incrementally

### DIFF
--- a/lib/autoproj.rb
+++ b/lib/autoproj.rb
@@ -44,6 +44,7 @@ require 'autoproj/query_base'
 require 'autoproj/source_package_query'
 require 'autoproj/os_package_query'
 
+require 'autoproj/ops/phase_reporting'
 require 'autoproj/ops/install'
 require 'autoproj/ops/tools'
 require 'autoproj/ops/loader'

--- a/lib/autoproj/cli/test.rb
+++ b/lib/autoproj/cli/test.rb
@@ -10,7 +10,7 @@ module Autoproj
             end
 
             def package_metadata(package)
-                u = package.autobuild.test_utility
+                u = package.test_utility
                 super.merge(
                     'coverage_available' => !!u.coverage_available?,
                     'coverage_enabled' => !!u.coverage_enabled?,

--- a/lib/autoproj/ops/phase_reporting.rb
+++ b/lib/autoproj/ops/phase_reporting.rb
@@ -1,0 +1,49 @@
+module Autoproj
+    module Ops
+        # Common logic to generate build/import/utility reports
+        class PhaseReporting
+            def initialize(name, path, metadata_get)
+                @name = name
+                @path = path
+                @metadata_get = metadata_get
+            end
+
+            def create_report(autobuild_packages)
+                info = autobuild_packages.each_with_object({}) do |p, map|
+                    map[p.name] = @metadata_get.call(p)
+                end
+
+                dump = JSON.dump(
+                    "#{@name}_report" => {
+                        'timestamp' => Time.now,
+                        'packages' => info
+                    }
+                )
+
+                FileUtils.mkdir_p File.dirname(@path)
+                File.open(@path, 'w') do |io|
+                    io.write dump
+                end
+            end
+
+            def initialize_incremental_report
+                FileUtils.mkdir_p File.dirname(@path)
+                @incremental_report = ""
+            end
+
+            def report_incremental(autobuild_package)
+                new_metadata = @metadata_get.call(autobuild_package)
+                prefix = @incremental_report.empty? ? "\n" : ",\n"
+                @incremental_report.concat(
+                    "#{prefix}\"#{autobuild_package.name}\": #{JSON.dump(new_metadata)}"
+                )
+                File.open(@path, 'w') do |io|
+                    io.write "{ \"#{@name}_report\": "\
+                             "{\"timestamp\": #{JSON.dump(Time.now)}, \"packages\": {"
+                    io.write(@incremental_report)
+                    io.write "}}}"
+                end
+            end
+        end
+    end
+end

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -80,6 +80,7 @@ module Autoproj
             @tmpdir.each do |dir|
                 FileUtils.remove_entry_secure dir
             end
+            Rake::Task.clear
             Autobuild::Package.clear
             Autoproj.silent = false
 

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -371,9 +371,16 @@ gem 'autobuild', path: '#{autobuild_dir}'
 
         def ws_define_package(package_type, package_name,
                               package_set: ws.manifest.main_package_set,
-                              create: true)
+                              create: true, &block)
             package = Autobuild.send(package_type, package_name)
-            package.srcdir = File.join(ws.root_dir, package_name.to_s)
+            ws_setup_package(
+                package, package_set: package_set, create: create, &block
+            )
+        end
+
+        def ws_setup_package(package, package_set: ws.manifest.main_package_set,
+                                      create: true)
+            package.srcdir = File.join(ws.root_dir, package.name.to_s)
             FileUtils.mkdir_p package.srcdir if create
             autoproj_package = ws.register_package(package, nil, package_set)
             yield(package) if block_given?


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/autobuild/pull/78

Apart from being generally nicer (you do get a report even if the build fails in unexpected ways), this ensures that we get a usable report even if the build is terminated hard, for instance
when CI timeouts fail.

In CI context, it avoids having to re-do a complete build and/or test cycle if the CI timeout triggers.