### PR TITLE
cache: properly autodetect 'gem' in when attempting to compile gems

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -23,6 +23,36 @@ module Autoproj
         class Install
             class UnexpectedBinstub < RuntimeError; end
 
+            RUBYLIB_REINIT = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    end
+                elsif ENV['RUBYLIB']
+                    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                end
+            RUBY
+
+            WITHOUT_BUNDLER = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec($0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec($0, *ARGV)
+                        end
+                    end
+                end
+            RUBY
+
             # The created workspace's root directory
             attr_reader :root_dir
             # Content of the Gemfile generated to install autoproj itself
@@ -435,11 +465,7 @@ module Autoproj
 #
 
 # Autoproj generated preamble
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -451,12 +477,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
             def self.shim_bundler_old(ruby_executable, autoproj_gemfile_path, gems_gem_home)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
-
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -481,14 +502,7 @@ load Gem.bin_path('bundler', 'bundler')"
 #
 
 # Autoproj generated preamble, v1
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
@@ -500,14 +514,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
                 gems_gem_home, load_line)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 require 'rubygems'

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -23,6 +23,36 @@ module Autoproj
         class Install
             class UnexpectedBinstub < RuntimeError; end
 
+            RUBYLIB_REINIT = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    end
+                elsif ENV['RUBYLIB']
+                    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                end
+            RUBY
+
+            WITHOUT_BUNDLER = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec($0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec($0, *ARGV)
+                        end
+                    end
+                end
+            RUBY
+
             # The created workspace's root directory
             attr_reader :root_dir
             # Content of the Gemfile generated to install autoproj itself
@@ -435,11 +465,7 @@ module Autoproj
 #
 
 # Autoproj generated preamble
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -451,12 +477,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
             def self.shim_bundler_old(ruby_executable, autoproj_gemfile_path, gems_gem_home)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
-
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -481,14 +502,7 @@ load Gem.bin_path('bundler', 'bundler')"
 #
 
 # Autoproj generated preamble, v1
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
@@ -500,14 +514,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
                 gems_gem_home, load_line)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 require 'rubygems'

--- a/lib/autoproj/base.rb
+++ b/lib/autoproj/base.rb
@@ -56,4 +56,22 @@ module Autoproj
             end
         end
     end
+
+    # Shim for a smooth upgrade path to bundler 2.1+
+    def self.bundler_unbundled_system(*args, **options)
+        if Bundler.respond_to?(:unbundled_system)
+            Bundler.unbundled_system(*args, **options)
+        else
+            Bundler.clean_system(*args, **options)
+        end
+    end
+
+    # Shim for a smooth upgrade path to bundler 2.1+
+    def self.bundler_with_unbundled_env(&block)
+        if Bundler.respond_to?(:with_unbundled_env)
+            Bundler.with_unbundled_env(&block)
+        else
+            Bundler.with_clean_env(&block)
+        end
+    end
 end

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -13,6 +13,36 @@ module Autoproj
         class Install
             class UnexpectedBinstub < RuntimeError; end
 
+            RUBYLIB_REINIT = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                        end
+                    end
+                elsif ENV['RUBYLIB']
+                    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
+                end
+            RUBY
+
+            WITHOUT_BUNDLER = <<~RUBY
+                if defined?(Bundler)
+                    if Bundler.respond_to?(:with_unbundled_env)
+                        Bundler.with_unbundled_env do
+                            exec($0, *ARGV)
+                        end
+                    else
+                        Bundler.with_clean_env do
+                            exec($0, *ARGV)
+                        end
+                    end
+                end
+            RUBY
+
             # The created workspace's root directory
             attr_reader :root_dir
             # Content of the Gemfile generated to install autoproj itself
@@ -425,11 +455,7 @@ module Autoproj
 #
 
 # Autoproj generated preamble
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -441,12 +467,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
             def self.shim_bundler_old(ruby_executable, autoproj_gemfile_path, gems_gem_home)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec($0, *ARGV)
-    end
-end
-
+#{WITHOUT_BUNDLER}
 ENV['BUNDLE_GEMFILE'] ||= '#{autoproj_gemfile_path}'
 ENV['GEM_HOME'] = '#{gems_gem_home}'
 ENV.delete('GEM_PATH')
@@ -471,14 +492,7 @@ load Gem.bin_path('bundler', 'bundler')"
 #
 
 # Autoproj generated preamble, v1
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
@@ -490,14 +504,7 @@ Gem.paths = Hash['GEM_HOME' => '#{gems_gem_home}', 'GEM_PATH' => '']
                 gems_gem_home, load_line)
 "#! #{ruby_executable}
 
-if defined?(Bundler)
-    Bundler.with_clean_env do
-        exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-    end
-elsif ENV['RUBYLIB']
-    exec(Hash['RUBYLIB' => nil], $0, *ARGV)
-end
-
+#{RUBYLIB_REINIT}
 ENV['BUNDLE_GEMFILE'] = '#{autoproj_gemfile_path}'
 ENV['AUTOPROJ_CURRENT_ROOT'] = '#{root_dir}'
 require 'rubygems'

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -351,7 +351,7 @@ module Autoproj
                                  gemfile: default_gemfile_path(ws))
                 bundle = Autobuild.programs['bundle'] || default_bundler(ws)
 
-                Bundler.with_clean_env do
+                Autoproj.bundler_with_unbundled_env do
                     target_env = Hash[
                         'GEM_HOME' => gem_home,
                         'GEM_PATH' => nil,
@@ -529,7 +529,7 @@ module Autoproj
             def discover_rubylib
                 require 'bundler'
                 Tempfile.open 'autoproj-rubylib' do |io|
-                    result = Bundler.clean_system(
+                    result = Autoproj.bundler_unbundled_system(
                         Hash['RUBYLIB' => nil],
                         Autobuild.tool('ruby'), '-e', 'puts $LOAD_PATH',
                         out: io,
@@ -553,7 +553,7 @@ module Autoproj
                 silent_redirect[:err] = :close if silent_errors
                 env = ws.env.resolved_env
                 Tempfile.open 'autoproj-rubylib' do |io|
-                    result = Bundler.clean_system(
+                    result = Autoproj.bundler_unbundled_system(
                         Hash['GEM_HOME' => env['GEM_HOME'], 'GEM_PATH' => env['GEM_PATH'],
                              'BUNDLE_GEMFILE' => gemfile, 'RUBYOPT' => nil,
                              'RUBYLIB' => self.class.rubylib_for_bundler],

--- a/lib/autoproj/package_managers/homebrew_manager.rb
+++ b/lib/autoproj/package_managers/homebrew_manager.rb
@@ -15,7 +15,7 @@ module Autoproj
                 # somewhere else
                 packages = packages.uniq
                 command_line = "brew info --json=v1 #{packages.join(' ')}"
-                result = Bundler.with_clean_env do
+                result = Autoproj.bundler_with_unbundled_env do
                     (Autobuild::Subprocess.run 'autoproj', 'osdeps', command_line).first
                 end
 
@@ -30,7 +30,7 @@ module Autoproj
                     end
                     return packages
                 end
-                
+
                 # fall back if something else went wrong
                 if packages.size != result.size
                     Autoproj.warn "brew info returns less or more packages when requested. Falling back to install all packages"

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -176,7 +176,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
                     'PACKAGE_BASE_DIR' => package_base_dir,
                     'RUBY' => Gem.ruby
                 ]
-                result = Bundler.clean_system(
+                result = Autoproj.bundler_unbundled_system(
                     default_env.merge(env), script, *arguments,
                     in: :close, **Hash[chdir: dir].merge(system_options))
             end
@@ -207,7 +207,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
             cached_bundler_gem = File.join(vendor, bundler_filename)
             unless File.file?(cached_bundler_gem)
                 FileUtils.mkdir_p vendor
-                Bundler.clean_system(
+                Autoproj.bundler_unbundled_system(
                     Ops::Install.guess_gem_program, 'fetch', '-v',
                     Bundler::VERSION, 'bundler', chdir: vendor)
 
@@ -217,7 +217,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
             end
 
             capture_subprocess_io do
-                Bundler.clean_system(
+                Autoproj.bundler_unbundled_system(
                     Hash['GEM_HOME' => fixture_gem_home, 'GEM_PATH' => nil],
                     Ops::Install.guess_gem_program, 'install', '--no-document',
                     cached_bundler_gem)
@@ -262,7 +262,7 @@ gem 'autobuild', path: '#{autobuild_dir}'
 
         def find_bundled_gem_path(bundler, gem_name, gemfile)
             out_r, out_w = IO.pipe
-            result = Bundler.clean_system(
+            result = Autoproj.bundler_unbundled_system(
                 bundler, 'show', gem_name,
                 out: out_w,
                 chdir: File.dirname(gemfile))

--- a/test/ops/test_install.rb
+++ b/test/ops/test_install.rb
@@ -59,7 +59,7 @@ gem 'autobuild', path: '#{autobuild_dir}'"
                     shim_path = File.join(install_dir, '.autoproj', 'bin', 'bundle')
                     assert File.file?(shim_path)
                     stdout, _stderr = capture_subprocess_io do
-                        unless Bundler.clean_system(shim_path, 'show', 'bundler')
+                        unless Autoproj.bundler_unbundled_system(shim_path, 'show', 'bundler')
                             flunk("could not run the bundler shim")
                         end
                     end
@@ -118,7 +118,7 @@ gem 'autobuild', path: '#{autobuild_dir}'"
                     shim_path = File.join(install_dir, '.autoproj', 'bin', 'bundle')
                     assert File.file?(shim_path)
                     stdout, _stderr = capture_subprocess_io do
-                        unless Bundler.clean_system(shim_path, 'show', 'bundler')
+                        unless Autoproj.bundler_unbundled_system(shim_path, 'show', 'bundler')
                             flunk("could not run the bundler shim")
                         end
                     end

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -164,7 +164,7 @@ module Autoproj
                 out, err = capture_subprocess_io do
                     system(Hash['__AUTOPROJ_TEST_FAKE_VERSION' => "2.99.90"],
                         "rake", "build")
-                    install_successful = Bundler.clean_system(
+                    install_successful = Autoproj.bundler_unbundled_system(
                         Hash['GEM_HOME' => fixture_gem_home],
                         Ops::Install.guess_gem_program, 'install',
                         '--ignore-dependencies', '--no-document',
@@ -192,7 +192,7 @@ module Autoproj
                 capture_subprocess_io do
                     system(Hash['__AUTOPROJ_TEST_FAKE_VERSION' => "2.99.99"],
                         "rake", "build")
-                    Bundler.clean_system(
+                    Autoproj.bundler_unbundled_system(
                         Hash['GEM_HOME' => fixture_gem_home],
                         Ops::Install.guess_gem_program, 'install',
                         '--ignore-dependencies', '--no-document',
@@ -201,7 +201,7 @@ module Autoproj
 
                 result = nil
                 stdout, stderr = capture_subprocess_io do
-                    result = Bundler.clean_system(
+                    result = Autoproj.bundler_unbundled_system(
                         File.join('.autoproj', 'bin', 'autoproj'), 'update', '--autoproj',
                         chdir: install_dir)
                 end


### PR DESCRIPTION
The current code fails on systems with rbenv