### PR TITLE
add support to pin an autoproj workspace to a specific bundler version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,9 +17,6 @@ Style/TrivialAccessors:
 Naming/PredicateName:
     Enabled: false
 
-Lint/SplatKeywordArguments:
-    Enabled: false
-
 Style/FrozenStringLiteralComment:
     Enabled: false
 
@@ -33,22 +30,22 @@ Naming/FileName:
 Metrics/ParameterLists:
     Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
     AllowedNames: [io, id, to, by, on, in, at, ip, db, ws]
 
 
 
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
     Enabled: false
 
 Layout/DotPosition:
     Enabled: false
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
     Enabled: false
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
     Enabled: false
 
 Layout/IndentationWidth:
@@ -102,7 +99,7 @@ Style/PerlBackrefs:
 Style/StringLiterals:
     Enabled: false
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
     Enabled: false
 
 Metrics/LineLength:

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -8,10 +8,13 @@ elsif ENV['AUTOPROJ_CURRENT_ROOT'] && (ENV['AUTOPROJ_CURRENT_ROOT'] != Dir.pwd)
     exit 1
 end
 
+# frozen_string_literal: true
+
 require 'pathname'
 require 'optparse'
 require 'fileutils'
 require 'yaml'
+require 'English'
 
 module Autoproj
     module Ops
@@ -260,6 +263,10 @@ module Autoproj
                  "gem \"utilrb\", \">= 3.0.1\""].join("\n")
             end
 
+            def add_seed_config(path)
+                @config.merge!(YAML.safe_load(File.read(path)))
+            end
+
             # Parse the provided command line options and returns the non-options
             def parse_options(args = ARGV)
                 options = OptionParser.new do |opt|
@@ -297,9 +304,14 @@ module Autoproj
                         end
                         @gemfile = File.read(path)
                     end
+                    opt.on '--no-seed-config',
+                           'when reinstalling an existing autoproj workspace, do not '\
+                           'use the config in .autoproj/ as seed' do
+                        @config.clear
+                    end
                     opt.on '--seed-config=PATH', String, 'path to a seed file that '\
                         'should be used to initialize the configuration' do |path|
-                        @config.merge!(YAML.load(File.read(path)))
+                        add_seed_config(path)
                     end
                     opt.on '--prefer-os-independent-packages', 'prefer OS-independent '\
                         'packages (such as a RubyGem) over their OS-packaged equivalent '\
@@ -409,7 +421,7 @@ module Autoproj
                     root_dir, autoproj_gemfile_path, gems_gem_home)
             end
 
-            EXCLUDED_FROM_SHIMS = %w{rake thor}
+            EXCLUDED_FROM_SHIMS = %w[rake thor].freeze
 
             def self.rewrite_shims(shim_path, ruby_executable,
                 root_dir, autoproj_gemfile_path, gems_gem_home)
@@ -608,8 +620,11 @@ require 'bundler/setup'
                 #
                 # So, we're calling 'gem' as a subcommand to discovery the
                 # actual bindir
-                bindir = IO.popen(env_for_child,
-                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
+                bindir = IO.popen(
+                    env_for_child,
+                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"'], # rubocop:disable Lint/InterpolationCheck
+                    &:read
+                )
                 if bindir
                     @gem_bindir = bindir.chomp
                 else
@@ -620,8 +635,8 @@ require 'bundler/setup'
             def install
                 if ENV['BUNDLER_GEMFILE']
                     raise "cannot run autoproj_install or autoproj_bootstrap while "\
-                        "under a 'bundler exec' subcommand or having loaded an env.sh. "\
-                        "Open a new console and try again"
+                          "under a 'bundler exec' subcommand or having loaded an "\
+                          "env.sh. Open a new console and try again"
                 end
 
                 gem_program  = self.class.guess_gem_program
@@ -749,12 +764,14 @@ end
 ENV.delete('BUNDLE_GEMFILE')
 ENV.delete('RUBYLIB')
 ops = Autoproj::Ops::Install.new(Dir.pwd)
+
+existing_config = File.join(Dir.pwd, '.autoproj', 'config.yml')
+if File.file?(existing_config)
+    puts "Found existing configuration, using it as seed"
+    puts "use --no-seed-config to avoid this behavior"
+    ops.add_seed_config(existing_config)
+end
 bootstrap_options = ops.parse_options(ARGV)
 ops.stage1
-if !ops.skip_stage2?
-    ops.call_stage2
-end
-if !ops.run_autoproj 'bootstrap', *bootstrap_options
-    exit 1
-end
-
+ops.call_stage2 unless ops.skip_stage2?
+exit 1 unless ops.run_autoproj('bootstrap', *bootstrap_options)

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -290,6 +290,10 @@ module Autoproj
                     opt.on '--public-gems', "install gems in the default gem location" do
                         self.install_gems_in_gem_user_dir
                     end
+                    opt.on '--bundler-version=VERSION_CONSTRAINT', String, 'use the provided '\
+                        'string as a version constraint for bundler' do |version|
+                        @config['bundler_version'] = version
+                    end
                     opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided '\
                         'string as a version constraint for autoproj' do |version|
                         if @gemfile
@@ -341,28 +345,59 @@ module Autoproj
                 @autoproj_options + args
             end
 
-            def find_bundler(gem_program)
-                setup_paths =
-                    IO.popen([env_for_child, Gem.ruby, gem_program, 'which','-a', 'bundler/setup']) do |io|
-                        io.read
-                    end
-                return unless $?.success?
-                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                setup_paths.each_line do |setup_path|
-                    if File.exist?(bundler_path) && setup_path.start_with?(gems_gem_home)
-                        return bundler_path
-                    end
-                end
-                return
+            def bundler_version
+                @config['bundler_version']
             end
 
-            def install_bundler(gem_program, silent: false)
+            def find_bundler(gem_program, version: nil)
+                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
+                return unless File.exist?(bundler_path)
+
+                setup_paths =
+                    if version
+                        find_versioned_bundler_setup(gem_program, version)
+                    else
+                        find_unversioned_bundler_setup(gem_program)
+                    end
+
+                setup_paths.each do |setup_path|
+                    return bundler_path if setup_path.start_with?(gems_gem_home)
+                end
+                nil
+            end
+
+            def find_versioned_bundler_setup(gem_program, version)
+                contents = IO.popen(
+                    [env_for_child, Gem.ruby, gem_program,
+                     'contents', '-v', version, 'bundler'],
+                    &:readlines
+                )
+                return [] unless $CHILD_STATUS.success?
+
+                contents.grep(%r{bundler/setup.rb$})
+            end
+
+            def find_unversioned_bundler_setup(gem_program)
+                setup_paths = IO.popen(
+                    [env_for_child, Gem.ruby, gem_program,
+                     'which', '-a', 'bundler/setup'],
+                    &:readlines
+                )
+                return [] unless $CHILD_STATUS.success?
+
+                setup_paths
+            end
+
+            def install_bundler(gem_program, version: nil, silent: false)
                 local = ['--local'] if local?
 
                 redirection = Hash.new
                 if silent
                     redirection = Hash[out: :close]
                 end
+
+                version_args = []
+                version_args << '-v' << version if version
 
                 # Shut up the bundler warning about 'bin' not being in PATH
                 env = self.env
@@ -374,14 +409,14 @@ module Autoproj
                         '--clear-sources', '--source', gem_source,
                         '--no-user-install', '--install-dir', gems_gem_home,
                         *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
-                        'bundler', **redirection)
+                        'bundler', *version_args, **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
                     nil
                 end
 
-                if (bundler_path = find_bundler(gem_program))
+                if (bundler_path = find_bundler(gem_program, version: version))
                     bundler_path
                 else
                     STDERR.puts "gem install bundler returned successfully, but still "\
@@ -390,7 +425,7 @@ module Autoproj
                 end
             end
 
-            def install_autoproj(bundler)
+            def install_autoproj(bundler, bundler_version: self.bundler_version)
                 # Force bundler to update. If the user does not want this, let
                 # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, 'Gemfile.lock')
@@ -405,14 +440,19 @@ module Autoproj
                 opts << "--path=#{gems_install_path}"
                 shims_path = File.join(dot_autoproj, 'bin')
 
-                result = system(clean_env,
-                    Gem.ruby, bundler, 'install',
-                        "--gemfile=#{autoproj_gemfile_path}",
-                        "--shebang=#{Gem.ruby}",
-                        "--binstubs=#{shims_path}",
-                        *opts, chdir: dot_autoproj)
+                version_arg = []
+                version_arg << "_#{bundler_version}_" if bundler_version
 
-                if !result
+                result = system(
+                    clean_env,
+                    Gem.ruby, bundler, *version_arg, 'install',
+                    "--gemfile=#{autoproj_gemfile_path}",
+                    "--shebang=#{Gem.ruby}",
+                    "--binstubs=#{shims_path}",
+                    *opts, chdir: dot_autoproj
+                )
+
+                unless result
                     STDERR.puts "FATAL: failed to install autoproj in #{dot_autoproj}"
                     exit 1
                 end
@@ -632,7 +672,7 @@ require 'bundler/setup'
                 end
             end
 
-            def install
+            def install(bundler_version: self.bundler_version)
                 if ENV['BUNDLER_GEMFILE']
                     raise "cannot run autoproj_install or autoproj_bootstrap while "\
                           "under a 'bundler exec' subcommand or having loaded an "\
@@ -644,13 +684,12 @@ require 'bundler/setup'
                 env['GEM_HOME'] = [gems_gem_home]
                 env['GEM_PATH'] = [gems_gem_home]
 
-                if bundler = find_bundler(gem_program)
+                if (bundler = find_bundler(gem_program, version: bundler_version))
                     puts "Detected bundler at #{bundler}"
                 else
                     puts "Installing bundler in #{gems_gem_home}"
-                    if !(bundler = install_bundler(gem_program))
-                        exit 1
-                    end
+                    bundler = install_bundler(gem_program, version: bundler_version)
+                    exit(1) unless bundler
                 end
                 self.class.rewrite_shims(
                     File.join(dot_autoproj, 'bin'),
@@ -662,7 +701,7 @@ require 'bundler/setup'
                 save_gemfile
 
                 puts "Installing autoproj in #{gems_gem_home}"
-                install_autoproj(bundler)
+                install_autoproj(bundler, bundler_version: bundler_version)
             end
 
             def load_config

--- a/bin/autoproj_bootstrap.in
+++ b/bin/autoproj_bootstrap.in
@@ -13,12 +13,14 @@ require 'autoproj/ops/install'
 ENV.delete('BUNDLE_GEMFILE')
 ENV.delete('RUBYLIB')
 ops = Autoproj::Ops::Install.new(Dir.pwd)
+
+existing_config = File.join(Dir.pwd, '.autoproj', 'config.yml')
+if File.file?(existing_config)
+    puts "Found existing configuration, using it as seed"
+    puts "use --no-seed-config to avoid this behavior"
+    ops.add_seed_config(existing_config)
+end
 bootstrap_options = ops.parse_options(ARGV)
 ops.stage1
-if !ops.skip_stage2?
-    ops.call_stage2
-end
-if !ops.run_autoproj 'bootstrap', *bootstrap_options
-    exit 1
-end
-
+ops.call_stage2 unless ops.skip_stage2?
+exit 1 unless ops.run_autoproj('bootstrap', *bootstrap_options)

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -8,10 +8,13 @@ elsif ENV['AUTOPROJ_CURRENT_ROOT'] && (ENV['AUTOPROJ_CURRENT_ROOT'] != Dir.pwd)
     exit 1
 end
 
+# frozen_string_literal: true
+
 require 'pathname'
 require 'optparse'
 require 'fileutils'
 require 'yaml'
+require 'English'
 
 module Autoproj
     module Ops
@@ -260,6 +263,10 @@ module Autoproj
                  "gem \"utilrb\", \">= 3.0.1\""].join("\n")
             end
 
+            def add_seed_config(path)
+                @config.merge!(YAML.safe_load(File.read(path)))
+            end
+
             # Parse the provided command line options and returns the non-options
             def parse_options(args = ARGV)
                 options = OptionParser.new do |opt|
@@ -297,9 +304,14 @@ module Autoproj
                         end
                         @gemfile = File.read(path)
                     end
+                    opt.on '--no-seed-config',
+                           'when reinstalling an existing autoproj workspace, do not '\
+                           'use the config in .autoproj/ as seed' do
+                        @config.clear
+                    end
                     opt.on '--seed-config=PATH', String, 'path to a seed file that '\
                         'should be used to initialize the configuration' do |path|
-                        @config.merge!(YAML.load(File.read(path)))
+                        add_seed_config(path)
                     end
                     opt.on '--prefer-os-independent-packages', 'prefer OS-independent '\
                         'packages (such as a RubyGem) over their OS-packaged equivalent '\
@@ -409,7 +421,7 @@ module Autoproj
                     root_dir, autoproj_gemfile_path, gems_gem_home)
             end
 
-            EXCLUDED_FROM_SHIMS = %w{rake thor}
+            EXCLUDED_FROM_SHIMS = %w[rake thor].freeze
 
             def self.rewrite_shims(shim_path, ruby_executable,
                 root_dir, autoproj_gemfile_path, gems_gem_home)
@@ -608,8 +620,11 @@ require 'bundler/setup'
                 #
                 # So, we're calling 'gem' as a subcommand to discovery the
                 # actual bindir
-                bindir = IO.popen(env_for_child,
-                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"']).read
+                bindir = IO.popen(
+                    env_for_child,
+                    [Gem.ruby, '-e', 'puts "#{Gem.user_dir}/bin"'], # rubocop:disable Lint/InterpolationCheck
+                    &:read
+                )
                 if bindir
                     @gem_bindir = bindir.chomp
                 else
@@ -620,8 +635,8 @@ require 'bundler/setup'
             def install
                 if ENV['BUNDLER_GEMFILE']
                     raise "cannot run autoproj_install or autoproj_bootstrap while "\
-                        "under a 'bundler exec' subcommand or having loaded an env.sh. "\
-                        "Open a new console and try again"
+                          "under a 'bundler exec' subcommand or having loaded an "\
+                          "env.sh. Open a new console and try again"
                 end
 
                 gem_program  = self.class.guess_gem_program
@@ -749,8 +764,13 @@ end
 ENV.delete('BUNDLE_GEMFILE')
 ENV.delete('RUBYLIB')
 ops = Autoproj::Ops::Install.new(Dir.pwd)
+
+existing_config = File.join(Dir.pwd, '.autoproj', 'config.yml')
+if File.file?(existing_config)
+    puts "Found existing configuration, using it as seed"
+    puts "use --no-seed-config to avoid this behavior"
+    ops.add_seed_config(existing_config)
+end
 ops.parse_options(ARGV)
 ops.stage1
-if !ops.skip_stage2?
-    ops.call_stage2
-end
+ops.call_stage2 unless ops.skip_stage2?

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -290,6 +290,10 @@ module Autoproj
                     opt.on '--public-gems', "install gems in the default gem location" do
                         self.install_gems_in_gem_user_dir
                     end
+                    opt.on '--bundler-version=VERSION_CONSTRAINT', String, 'use the provided '\
+                        'string as a version constraint for bundler' do |version|
+                        @config['bundler_version'] = version
+                    end
                     opt.on '--version=VERSION_CONSTRAINT', String, 'use the provided '\
                         'string as a version constraint for autoproj' do |version|
                         if @gemfile
@@ -341,28 +345,59 @@ module Autoproj
                 @autoproj_options + args
             end
 
-            def find_bundler(gem_program)
-                setup_paths =
-                    IO.popen([env_for_child, Gem.ruby, gem_program, 'which','-a', 'bundler/setup']) do |io|
-                        io.read
-                    end
-                return unless $?.success?
-                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
-                setup_paths.each_line do |setup_path|
-                    if File.exist?(bundler_path) && setup_path.start_with?(gems_gem_home)
-                        return bundler_path
-                    end
-                end
-                return
+            def bundler_version
+                @config['bundler_version']
             end
 
-            def install_bundler(gem_program, silent: false)
+            def find_bundler(gem_program, version: nil)
+                bundler_path = File.join(gems_gem_home, 'bin', 'bundle')
+                return unless File.exist?(bundler_path)
+
+                setup_paths =
+                    if version
+                        find_versioned_bundler_setup(gem_program, version)
+                    else
+                        find_unversioned_bundler_setup(gem_program)
+                    end
+
+                setup_paths.each do |setup_path|
+                    return bundler_path if setup_path.start_with?(gems_gem_home)
+                end
+                nil
+            end
+
+            def find_versioned_bundler_setup(gem_program, version)
+                contents = IO.popen(
+                    [env_for_child, Gem.ruby, gem_program,
+                     'contents', '-v', version, 'bundler'],
+                    &:readlines
+                )
+                return [] unless $CHILD_STATUS.success?
+
+                contents.grep(%r{bundler/setup.rb$})
+            end
+
+            def find_unversioned_bundler_setup(gem_program)
+                setup_paths = IO.popen(
+                    [env_for_child, Gem.ruby, gem_program,
+                     'which', '-a', 'bundler/setup'],
+                    &:readlines
+                )
+                return [] unless $CHILD_STATUS.success?
+
+                setup_paths
+            end
+
+            def install_bundler(gem_program, version: nil, silent: false)
                 local = ['--local'] if local?
 
                 redirection = Hash.new
                 if silent
                     redirection = Hash[out: :close]
                 end
+
+                version_args = []
+                version_args << '-v' << version if version
 
                 # Shut up the bundler warning about 'bin' not being in PATH
                 env = self.env
@@ -374,14 +409,14 @@ module Autoproj
                         '--clear-sources', '--source', gem_source,
                         '--no-user-install', '--install-dir', gems_gem_home,
                         *local, "--bindir=#{File.join(gems_gem_home, 'bin')}",
-                        'bundler', **redirection)
+                        'bundler', *version_args, **redirection)
 
                 if !result
                     STDERR.puts "FATAL: failed to install bundler in #{gems_gem_home}"
                     nil
                 end
 
-                if (bundler_path = find_bundler(gem_program))
+                if (bundler_path = find_bundler(gem_program, version: version))
                     bundler_path
                 else
                     STDERR.puts "gem install bundler returned successfully, but still "\
@@ -390,7 +425,7 @@ module Autoproj
                 end
             end
 
-            def install_autoproj(bundler)
+            def install_autoproj(bundler, bundler_version: self.bundler_version)
                 # Force bundler to update. If the user does not want this, let
                 # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, 'Gemfile.lock')
@@ -405,14 +440,19 @@ module Autoproj
                 opts << "--path=#{gems_install_path}"
                 shims_path = File.join(dot_autoproj, 'bin')
 
-                result = system(clean_env,
-                    Gem.ruby, bundler, 'install',
-                        "--gemfile=#{autoproj_gemfile_path}",
-                        "--shebang=#{Gem.ruby}",
-                        "--binstubs=#{shims_path}",
-                        *opts, chdir: dot_autoproj)
+                version_arg = []
+                version_arg << "_#{bundler_version}_" if bundler_version
 
-                if !result
+                result = system(
+                    clean_env,
+                    Gem.ruby, bundler, *version_arg, 'install',
+                    "--gemfile=#{autoproj_gemfile_path}",
+                    "--shebang=#{Gem.ruby}",
+                    "--binstubs=#{shims_path}",
+                    *opts, chdir: dot_autoproj
+                )
+
+                unless result
                     STDERR.puts "FATAL: failed to install autoproj in #{dot_autoproj}"
                     exit 1
                 end
@@ -632,7 +672,7 @@ require 'bundler/setup'
                 end
             end
 
-            def install
+            def install(bundler_version: self.bundler_version)
                 if ENV['BUNDLER_GEMFILE']
                     raise "cannot run autoproj_install or autoproj_bootstrap while "\
                           "under a 'bundler exec' subcommand or having loaded an "\
@@ -644,13 +684,12 @@ require 'bundler/setup'
                 env['GEM_HOME'] = [gems_gem_home]
                 env['GEM_PATH'] = [gems_gem_home]
 
-                if bundler = find_bundler(gem_program)
+                if (bundler = find_bundler(gem_program, version: bundler_version))
                     puts "Detected bundler at #{bundler}"
                 else
                     puts "Installing bundler in #{gems_gem_home}"
-                    if !(bundler = install_bundler(gem_program))
-                        exit 1
-                    end
+                    bundler = install_bundler(gem_program, version: bundler_version)
+                    exit(1) unless bundler
                 end
                 self.class.rewrite_shims(
                     File.join(dot_autoproj, 'bin'),
@@ -662,7 +701,7 @@ require 'bundler/setup'
                 save_gemfile
 
                 puts "Installing autoproj in #{gems_gem_home}"
-                install_autoproj(bundler)
+                install_autoproj(bundler, bundler_version: bundler_version)
             end
 
             def load_config

--- a/bin/autoproj_install.in
+++ b/bin/autoproj_install.in
@@ -13,8 +13,13 @@ require 'autoproj/ops/install'
 ENV.delete('BUNDLE_GEMFILE')
 ENV.delete('RUBYLIB')
 ops = Autoproj::Ops::Install.new(Dir.pwd)
+
+existing_config = File.join(Dir.pwd, '.autoproj', 'config.yml')
+if File.file?(existing_config)
+    puts "Found existing configuration, using it as seed"
+    puts "use --no-seed-config to avoid this behavior"
+    ops.add_seed_config(existing_config)
+end
 ops.parse_options(ARGV)
 ops.stage1
-if !ops.skip_stage2?
-    ops.call_stage2
-end
+ops.call_stage2 unless ops.skip_stage2?

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -355,6 +355,10 @@ module Autoproj
             set 'shell_helpers', flag, true
         end
 
+        def bundler_version
+            get 'bundler_version', nil
+        end
+
         def apply_autobuild_configuration
             if has_value_for?('autobuild')
                 params = get('autobuild')

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -424,7 +424,11 @@ module Autoproj
             gem_program = Ops::Install.guess_gem_program
             install = Ops::Install.new(root_dir)
             Autoproj.message "  updating bundler"
-            install.install_bundler(gem_program, silent: true)
+            install.install_bundler(
+                gem_program,
+                version: config.bundler_version,
+                silent: true
+            )
         end
 
         def update_autoproj(restart_on_update: true)
@@ -438,18 +442,21 @@ module Autoproj
             binstubs = File.join(dot_autoproj_dir, 'bin')
             if restart_on_update
                 old_autoproj_path = PackageManagers::BundlerManager.bundle_gem_path(
-                    self, 'autoproj', gem_home: config.gems_gem_home, gemfile: gemfile)
+                    self, 'autoproj', gemfile: gemfile
+                )
             end
             begin
                 Autoproj.message "  updating autoproj"
                 PackageManagers::BundlerManager.run_bundler_install(
-                    self, gemfile, binstubs: binstubs)
+                    self, gemfile, binstubs: binstubs
+                )
             ensure
                 rewrite_shims
             end
             if restart_on_update
                 new_autoproj_path = PackageManagers::BundlerManager.bundle_gem_path(
-                    self, 'autoproj', gem_home: config.gems_gem_home, gemfile: gemfile)
+                    self, 'autoproj', gemfile: gemfile
+                )
             end
 
             # First things first, see if we need to update ourselves

--- a/test/ops/test_install.rb
+++ b/test/ops/test_install.rb
@@ -209,6 +209,51 @@ gem 'autobuild', path: '#{autobuild_dir}'"
                     assert_equal true, new_config['test_v1_config']
                 end
             end
+
+            describe 'bundler versioning' do
+                it 'picks a specific bundler version as passed in the seed config' do
+                    seed_config_path = File.join(make_tmpdir, 'config.yml')
+                    File.open(seed_config_path, 'w') do |io|
+                        YAML.dump({ 'bundler_version' => '2.0.1' }, io)
+                    end
+
+                    dir, = invoke_test_script(
+                        'install.sh', '--seed-config', seed_config_path
+                    )
+                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                end
+
+                it 'picks a specific bundler version as passed on the command line' do
+                    dir, = invoke_test_script('install.sh', '--bundler-version', '2.0.1')
+                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                end
+
+                it 'pins the install to the selected bundler version' do
+                    dir, = invoke_test_script('install.sh', '--bundler-version', '2.0.1')
+                    `#{dir}/.autoproj/bin/autoproj update`
+                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                end
+
+                it 'can pin a bundler version on an existing bootstrap' do
+                    dir, = invoke_test_script('install.sh')
+                    refute_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    dir, = invoke_test_script('install.sh', '--bundler-version', '2.0.1')
+                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                end
+
+                it 'can unpin a bundler version after the bootstrap' do
+                    dir, = invoke_test_script('install.sh', '--bundler-version', '2.0.1')
+
+                    config_yml = File.join(dir, '.autoproj', 'config.yml')
+                    config = YAML.safe_load(File.read(config_yml))
+                    config.delete('bundler_version')
+                    File.open(config_yml, 'w') do |io|
+                        YAML.dump(config, io)
+                    end
+                    `#{dir}/.autoproj/bin/autoproj update`
+                    refute_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                end
+            end
         end
     end
 end

--- a/test/package_managers/test_bundler_manager.rb
+++ b/test/package_managers/test_bundler_manager.rb
@@ -11,6 +11,7 @@ module Autoproj
                       .with(any, any, '/some/path/bin/bundle', 'some', 'program', Hash, Proc)
                       .once
                     BundlerManager.run_bundler(ws, 'some', 'program',
+                                               bundler_version: nil,
                                                gem_home: '/gem/home',
                                                gemfile: '/gem/path/Gemfile')
                 end


### PR DESCRIPTION
At bootstrap, pass the `--bundler-version` argument.
In an existing workspace, you need to run autoproj_install with
the `--bundler-version` argument.