### PR TITLE
cache: update experimental --gem-compile support

### DIFF
--- a/lib/autoproj/cli/cache.rb
+++ b/lib/autoproj/cli/cache.rb
@@ -22,7 +22,16 @@ module Autoproj
 
                 if (compile = options[:gems_compile])
                     options[:gems_compile] = compile.map do |name|
-                        name, *artifacts = name.split('+')
+                        scanner = StringScanner.new(name)
+                        name = scanner.scan(/[^+-]+/)
+
+                        artifacts = []
+                        until scanner.eos?
+                            include = (scanner.getch == '+')
+                            glob = scanner.scan(/[^+-]+/)
+                            artifacts << [include, glob]
+                        end
+
                         [name, artifacts: artifacts]
                     end
                 end

--- a/lib/autoproj/ops/cache.rb
+++ b/lib/autoproj/ops/cache.rb
@@ -223,7 +223,13 @@ module Autoproj
             end
 
             private def compile_gem(gem_path, output:, artifacts: [])
-                artifacts = artifacts.flat_map { |n| ["--artifact", n] }
+                artifacts = artifacts.flat_map do |include, n|
+                    if include
+                        ["--include", n]
+                    else
+                        ["--exclude", n]
+                    end
+                end
                 unless system(Autobuild.tool('ruby'), '-S', guess_gem_program,
                               'compile', '--output', output, *artifacts, gem_path)
                     raise CompilationFailed, "#{gem_path} failed to compile"

--- a/lib/autoproj/ops/cache.rb
+++ b/lib/autoproj/ops/cache.rb
@@ -107,13 +107,20 @@ module Autoproj
                     begin
                         case pkg.importer
                         when Autobuild::Git
-                            Autoproj.message "  [#{i}/#{total}] caching #{pkg.name} (git)"
+                            Autoproj.message(
+                                "  [#{i}/#{total}] caching #{pkg.name} (git)"
+                            )
                             cache_git(pkg, checkout_only: checkout_only)
                         when Autobuild::ArchiveImporter
-                            Autoproj.message "  [#{i}/#{total}] caching #{pkg.name} (archive)"
+                            Autoproj.message(
+                                "  [#{i}/#{total}] caching #{pkg.name} (archive)"
+                            )
                             cache_archive(pkg)
                         else
-                            Autoproj.message "  [#{i}/#{total}] not caching #{pkg.name} (cannot cache #{pkg.importer.class})"
+                            Autoproj.message(
+                                "  [#{i}/#{total}] not caching #{pkg.name} "\
+                                "(cannot cache #{pkg.importer.class})"
+                            )
                         end
                     rescue Interrupt
                         raise
@@ -170,7 +177,9 @@ module Autoproj
                         next if !compile_force && File.file?(expected_platform_gem)
 
                         begin
-                            compile_gem(gem, artifacts: artifacts, output: real_target_dir)
+                            compile_gem(
+                                gem, artifacts: artifacts, output: real_target_dir
+                            )
                         rescue CompilationFailed
                             unless keep_going
                                 raise CompilationFailed, "#{gem} failed to compile"
@@ -200,17 +209,13 @@ module Autoproj
             end
 
             def guess_gem_program
-                if Autobuild.programs['gem']
-                    return Autobuild.programs['gem']
-                end
+                return Autobuild.programs['gem'] if Autobuild.programs['gem']
 
                 ruby_bin = RbConfig::CONFIG['RUBY_INSTALL_NAME']
                 ruby_bindir = RbConfig::CONFIG['bindir']
 
                 candidates = ['gem']
-                if ruby_bin =~ /^ruby(.+)$/
-                    candidates << "gem#{$1}"
-                end
+                candidates << "gem#{$1}" if ruby_bin =~ /^ruby(.+)$/
 
                 candidates.each do |gem_name|
                     if File.file?(gem_full_path = File.join(ruby_bindir, gem_name))
@@ -219,7 +224,9 @@ module Autoproj
                     end
                 end
 
-                raise ArgumentError, "cannot find a gem program (tried #{candidates.sort.join(", ")} in #{ruby_bindir})"
+                raise ArgumentError,
+                      'cannot find a gem program (tried '\
+                      "#{candidates.sort.join(', ')} in #{ruby_bindir})"
             end
 
             private def compile_gem(gem_path, output:, artifacts: [])

--- a/test/ops/test_cache.rb
+++ b/test/ops/test_cache.rb
@@ -59,7 +59,6 @@ module Autoproj
                     @gitrepo_path = File.join(root, 'cache-git')
 
                     @pkg = ws_define_package 'cmake', 'pkg'
-
                 end
 
                 it 'raises if given an invalid package name' do
@@ -69,7 +68,7 @@ module Autoproj
                 end
 
                 it 'resolves package names if given as argument' do
-                    packages = (1..5).map do |i|
+                    (1..5).each do |i|
                         pkg = ws_define_package 'cmake', "pkg#{i}"
                         pkg.autobuild.importer = Autobuild.git(@gitrepo_path)
 
@@ -81,7 +80,6 @@ module Autoproj
                         else
                             expectation.never
                         end
-                        pkg
                     end
 
                     Autoproj.should_receive(:message)
@@ -241,12 +239,17 @@ module Autoproj
                     @ops.should_receive(:system).explicitly.once
                         .with('myruby', '-S', 'mygem', 'compile',
                               '--output', @target_dir,
-                              '--artifact', 'some/lib',
-                              '--artifact', 'some/dir',
+                              '--include', 'some/lib',
+                              '--exclude', 'some/dir',
                               "#{@cache_dir}/gemname.gem")
                         .and_return(true)
                     @ops.create_or_update_gems(
-                        compile: [['gemname', artifacts: ['some/lib', 'some/dir']]]
+                        compile: [
+                            [
+                                'gemname',
+                                artifacts: [[true, 'some/lib'], [false, 'some/dir']]
+                            ]
+                        ]
                     )
                 end
 


### PR DESCRIPTION
Our latest patch for gem-compiler expanded on the initial --artifact
option to allow including and excluding parameters. Update support
in 'cache' to allow for +GLOB and -GLOB specifiers.

The syntax is `GEM_NAME[+INCLUDE][-EXCLUDE][...]`