### PR TITLE
raise PackageNotFound for missing dependencies from manifest

### DIFF
--- a/lib/autoproj/package_definition.rb
+++ b/lib/autoproj/package_definition.rb
@@ -90,7 +90,7 @@ module Autoproj
                         autobuild.depends_on name
                     end
                 rescue ConfigError => e
-                    raise ConfigError.new(manifest.path),
+                    raise PackageNotFound.new(manifest.path),
                           "manifest #{manifest.path} of #{self.name} from "\
                           "#{package_set.name} lists '#{name}' as dependency, "\
                           'but it is neither a normal package nor an osdeps '\

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -714,7 +714,7 @@ module Autoproj
                 "if it refers to a package that does not exist" do
                 manifest_path = ws_create_package_file pkg, "manifest.xml",
                     "<package><depend package=\"dependency\" /></package>"
-                e = assert_raises(ConfigError) do
+                e = assert_raises(PackageNotFound) do
                     manifest.load_package_manifest(pkg)
                 end
                 assert_equal "manifest #{manifest_path} of test from pkg_set lists "\


### PR DESCRIPTION
This is more consistent with what is done in other paces (i.e [here](https://github.com/rock-core/autoproj/blob/25b1f1a31618fd75689a35ebcdf1dcbd7b72a250/lib/autoproj/manifest.rb#L702))