### PR TITLE
Rescue, specify and reraise empty package name error

### DIFF
--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -61,6 +61,7 @@ module Autoproj
             end
 
             if data["layout"].member?(nil)
+                Autoproj.warn "There is an empty entry in your layout in #{file}. All empty entries are ignored."
                 data["layout"] = data["layout"].compact
             end
 

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -231,11 +231,11 @@ module Autoproj
                 validate_package_in_self(package)
                 package.name
             else
-		begin
+                begin
                     package = package.to_str
-		rescue NoMethodError
-		    raise ArgumentError, "no package name specified. check your manifest file for lines containing only a dash"
-		end
+                rescue NoMethodError
+                    raise ArgumentError, "no package name specified. check your manifest file for lines containing only a dash"
+                end
                 if require_existing && !has_package?(package)
                     raise PackageNotFound, "no package named #{package} in #{self}"
                 end

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -60,6 +60,10 @@ module Autoproj
                 YAML.safe_load(File.read(file)) || {}
             end
 
+            if data["layout"].member?(nil)
+                data["layout"] = data["layout"].compact
+            end
+
             @file = file
             initialize_from_hash(data)
         end
@@ -231,11 +235,7 @@ module Autoproj
                 validate_package_in_self(package)
                 package.name
             else
-                begin
-                    package = package.to_str
-                rescue NoMethodError
-                    raise ArgumentError, "no package name specified. check your manifest file for lines containing only a dash"
-                end
+                package = package.to_str
                 if require_existing && !has_package?(package)
                     raise PackageNotFound, "no package named #{package} in #{self}"
                 end

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -231,7 +231,11 @@ module Autoproj
                 validate_package_in_self(package)
                 package.name
             else
-                package = package.to_str
+		begin
+                    package = package.to_str
+		rescue NoMethodError
+		    raise ArgumentError, "no package name specified. check your manifest file for lines containing only a dash"
+		end
                 if require_existing && !has_package?(package)
                     raise PackageNotFound, "no package named #{package} in #{self}"
                 end


### PR DESCRIPTION
A misplaced or spare character (e.g. plus signs or backslashes) are detected by the yaml parser with a useful hint on the respective line number:

    could not find expected '+' while scanning a simple key at line 30 column 3

A misplaces dash on the other hand is only handles in the package_set section. When located within the layout section this causes the manifest.rb to throw a slightly confusing NoMethodError:

      .../manifest.rb:235:in `validate_package_name_argument': undefined method `to_str' for nil:NilClass (NoMethodError)

This PR solely rescues the error and raises a more specific ArgumentError. Alternatively and possibly more general one could check for package.nil? Not sure what's the preferred style here.

      if package.nil?
          raise ArgumentError, "no package name specified. check your manifest file for lines containing only a dash"
      end