### PR TITLE
Add safe navigation to layout read and test for it

### DIFF
--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -60,7 +60,7 @@ module Autoproj
                 YAML.safe_load(File.read(file)) || {}
             end
 
-            if data["layout"].member?(nil)
+            if data["layout"]&.member?(nil)
                 Autoproj.warn "There is an empty entry in your layout in #{file}. All empty entries are ignored."
                 data["layout"] = data["layout"].compact
             end

--- a/test/ops/test_configuration.rb
+++ b/test/ops/test_configuration.rb
@@ -424,6 +424,30 @@ module Autoproj
                 end
             end
 
+            describe "#load_no_packages_layout" do
+                it "load no layout" do
+                    FileUtils.mkdir_p ws.config_dir
+                    manifest_path = File.join(ws.config_dir, 'manifest')
+                    FileUtils.touch(manifest_path)
+                    ws.manifest.load manifest_path
+                    refute ws.manifest.has_layout?
+                end
+
+                it "load empty layout entry" do
+                    FileUtils.mkdir_p ws.config_dir
+                    manifest_path = File.join(ws.config_dir, 'manifest')
+                    File.open(manifest_path, 'w') do |io|
+                        YAML.dump(Hash['layout' => [nil]], io)
+                    end
+                    flexmock(Autoproj).should_receive(:warn).
+                        with("There is an empty entry in your layout in "/
+                            "#{manifest_path}. All empty entries are ignored.").
+                        once
+                    ws.manifest.load manifest_path
+                    assert ws.manifest.has_layout?
+                end
+            end
+
             describe "#load_package_set_information" do
                 before do
                     FileUtils.mkdir_p ws.config_dir


### PR DESCRIPTION
# Description

This PR basically adds safe navigation for the data["layout"] method call.

Plus, it adds two tests:

- Explicitly check for empty layout load. (I know that the tests were failing because of this call, but I did not see any explicit test for this)
- Warn output if an empty layout is present

I did not went through all the test cases to check if I created a repeated test (there is a lot...). I looked where it made sense for me, but I might be wrong.  

# Issue
closes #315 