### PR TITLE
Fixing slash on empty layout test

### DIFF
--- a/test/ops/test_configuration.rb
+++ b/test/ops/test_configuration.rb
@@ -440,7 +440,7 @@ module Autoproj
                         YAML.dump(Hash['layout' => [nil]], io)
                     end
                     flexmock(Autoproj).should_receive(:warn).
-                        with("There is an empty entry in your layout in "/
+                        with("There is an empty entry in your layout in "\
                             "#{manifest_path}. All empty entries are ignored.").
                         once
                     ws.manifest.load manifest_path


### PR DESCRIPTION
# Description

The main intention of this PR is to fix my misplaced slashed, where it should be backslash. I thought that I had run the tests just before creating the PR, but I have done something in the middle that I do not remember, sorry about that.

# Lint (rubocop)
I ran the rubocop on the files that I modified, however it didn't find any error on the code that I changed. Where did you see the lint problem exactly @g-arjones?

[Rubocop output for lib/autoproj/manifest.rb](https://github.com/rock-core/autoproj/files/5219354/manifest-rubocop-output.txt)
[Rubocop output for test/ops/test_configuration.rb](https://github.com/rock-core/autoproj/files/5219356/test_configuration-rubocop-output.txt)

# Also
Can you trigger the tests for this PR before merging ?
