### PR TITLE
generate an env.sh in the prefix and separate build dir roots

### DIFF
--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -807,6 +807,19 @@ module Autoproj
             full_env = self.full_env
             changed = save_cached_env(full_env)
             full_env.export_env_sh(shell_helpers: shell_helpers)
+
+            build_dir_is_absolute = Pathname(build_dir).absolute?
+            full_env.each_env_filename do |_, filename|
+                basename = File.basename(filename)
+                File.open(File.join(prefix_dir, basename), "w") do |io|
+                    io.puts "source \"#{filename}\""
+                end
+                if build_dir_is_absolute
+                    File.open(File.join(build_dir, basename), "w") do |io|
+                        io.puts "source \"#{filename}\""
+                    end
+                end
+            end
             changed
         end
 


### PR DESCRIPTION
This allows to spawn a new shell and load the env.sh there.