### PR TITLE
don't update Bundler's cache symlink if it exists and is pointing to the right place

### DIFF
--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -123,13 +123,14 @@ module Autoproj
             end
 
             def create_cache_symlink(cache_dir, bundler_cache_dir)
-                valid = !File.exist?(bundler_cache_dir) ||
-                        File.symlink?(bundler_cache_dir)
-
-                unless valid
-                    Autoproj.warn "cannot use #{cache_dir} as gem cache as "\
-                                  "#{bundler_cache_dir} already exists"
-                    return
+                if File.exist?(bundler_cache_dir)
+                    if !File.symlink?(bundler_cache_dir)
+                        Autoproj.warn "cannot use #{cache_dir} as gem cache as "\
+                                      "#{bundler_cache_dir} already exists"
+                        return
+                    elsif File.readlink(bundler_cache_dir) == cache_dir
+                        return
+                    end
                 end
 
                 FileUtils.rm_f bundler_cache_dir


### PR DESCRIPTION
I am hitting issues with multiple `autoproj exec` instances
being started in parallel, with some of them fail in this
codepath because they all try to re-create the symlink at the
same time.

This is a poor man's fix for it, basically assuming that the
symlink, once created, won't change.