### PR TITLE
fix(ops): fix cache on Autobuild >= v1.23 for packages that are not checked out

### DIFF
--- a/lib/autoproj/ops/cache.rb
+++ b/lib/autoproj/ops/cache.rb
@@ -43,7 +43,7 @@ module Autoproj
                         "--git-dir", pkg.importdir, 'init', "--bare"
                     )
                 end
-                pkg.importer.update_remotes_configuration(pkg)
+                pkg.importer.update_remotes_configuration(pkg, only_local: false)
 
                 with_retry(10) do
                     Autobuild::Subprocess.run(


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/autobuild/pull/105

In theory, Ops::Cache does not need a checked out package - this
is how the tests operate. It only acts on the git importer. This
particular workflow is broken on Autobuild 1.22 because we need
to have an autobuild remote to resolve the default HEAD, and
update_remotes_configuration - which is used by Ops::Cache -
would have only_local: false in this codepath

Autobuild v1.23 will allow to override only_local to true to fix
this.

Note that it does not affect the nominal `autoproj cache` workflow,
which acts on a checked out workspace for the purpose of dependency
resolution