### PR TITLE
WIP: Upgrade pip during bootstrap

### DIFF
--- a/lib/autoproj/package_managers/pip_manager.rb
+++ b/lib/autoproj/package_managers/pip_manager.rb
@@ -9,6 +9,7 @@ module Autoproj
             def initialize_environment
                 ws.env.set "PYTHONUSERBASE", pip_home
                 ws.env.add_path "PATH", File.join(pip_home, "bin")
+                Autoproj::Python.setup_python_configuration_options(ws: ws)
             end
 
             # Return the directory where python packages are installed to.

--- a/lib/autoproj/python.rb
+++ b/lib/autoproj/python.rb
@@ -213,6 +213,15 @@ module Autoproj
             pip_path
         end
 
+        def self.upgrade_pip(ws: Autoproj.workspace)
+            python_executable = ws.config.get("python_executable", nil)
+            unless python_executable.nil?
+                Open3.popen3(
+                    { "PYTHONUSERBASE" => ws.env["PYTHONUSERBASE"] },
+                    "#{python_executable} -m pip install --upgrade pip setuptools wheel")
+            end
+        end
+
         # Activate configuration for python in the autoproj configuration
         # @return [String,String] python path and python version
         def self.activate_python(ws: Autoproj.workspace,
@@ -226,6 +235,7 @@ module Autoproj
 
             rewrite_python_shims(bin, ws.prefix_dir)
             rewrite_pip_shims(bin, ws.prefix_dir)
+            upgrade_pip(ws: ws)
             [bin, version]
         end
 

--- a/lib/autoproj/python.rb
+++ b/lib/autoproj/python.rb
@@ -215,11 +215,12 @@ module Autoproj
 
         def self.upgrade_pip(ws: Autoproj.workspace)
             python_executable = ws.config.get("python_executable", nil)
-            unless python_executable.nil?
-                Open3.popen3(
-                    { "PYTHONUSERBASE" => ws.env["PYTHONUSERBASE"] },
-                    "#{python_executable} -m pip install --upgrade pip")
-            end
+            return if python_executable.nil?
+
+            Open3.popen3(
+                { "PYTHONUSERBASE" => ws.env["PYTHONUSERBASE"] },
+                "#{python_executable} -m pip install --upgrade pip"
+            )
         end
 
         # Activate configuration for python in the autoproj configuration

--- a/lib/autoproj/python.rb
+++ b/lib/autoproj/python.rb
@@ -218,7 +218,7 @@ module Autoproj
             unless python_executable.nil?
                 Open3.popen3(
                     { "PYTHONUSERBASE" => ws.env["PYTHONUSERBASE"] },
-                    "#{python_executable} -m pip install --upgrade pip setuptools wheel")
+                    "#{python_executable} -m pip install --upgrade pip")
             end
         end
 

--- a/test/scripts/seed-config.yml
+++ b/test/scripts/seed-config.yml
@@ -1,2 +1,4 @@
 osdeps_mode: 'all'
 apt_dpkg_update: true
+USE_PYTHON: true
+python_executable: '/usr/bin/python3'


### PR DESCRIPTION
Related issue: https://github.com/rock-core/autoproj/issues/338

Will make the prompt for enabling python move from aup to bootstrap.

Not sure if there are better ways to implement this, e.g., automatic via dependencies.

Seems to work on my machine, feel free to test.