### PR TITLE
declare python as a regular dependency on python packages

### DIFF
--- a/lib/autoproj/autobuild_extensions/dsl.rb
+++ b/lib/autoproj/autobuild_extensions/dsl.rb
@@ -198,7 +198,7 @@ end
 
 def python_package(name, workspace: Autoproj.workspace)
     package_common(:python, name, workspace: workspace) do |pkg|
-        pkg.internal_dependency "python"
+        pkg.depends_on "python"
         pkg.post_import do
             pkg.depends_on "python-setuptools" if pkg.install_mode?
         end


### PR DESCRIPTION
An internal dependency triggers installation unnecessarily during build.