### PR TITLE
install internal dependencies before calling post import blocks

### DIFF
--- a/lib/autoproj/ops/import.rb
+++ b/lib/autoproj/ops/import.rb
@@ -110,10 +110,6 @@ module Autoproj
                     end
                 end
 
-                if !manifest.excluded?(pkg.name) && !manifest.ignored?(pkg.name)
-                    process_post_import_blocks(pkg) if pkg.checked_out?
-                end
-
                 # The package setup mechanisms might have added an exclusion
                 # on this package. Handle this.
                 if manifest.excluded?(pkg.name)
@@ -468,6 +464,10 @@ module Autoproj
                 raise failures.first if !keep_going && !failures.empty?
 
                 install_internal_dependencies_for(*all_processed_packages)
+                all_processed_packages.each do |pkg|
+                    process_post_import_blocks(pkg) if pkg.checked_out?
+                end
+
                 finalize_package_load(all_processed_packages, auto_exclude: auto_exclude)
 
                 all_enabled_osdeps = selection.each_osdep_package_name.to_set


### PR DESCRIPTION
@doudou I wanted your thoughts before fixing the tests...

Post import blocks may have internal dependencies (i.e python activation code) so these must be installed before calling the blocks. I have delayed the processing of the blocks until all the packages have been processed so we can install the internal dependencies and call all the blocks at once afterward. I don't see issues.

The other possibility would be to leave the calling of post-import blocks alone and move the installation of internal dependencies to `Ops::Import#process_post_import_blocks` (would have to keep a cache to avoid calling `Manager#install` on the same packages more than once). That would mean potentially installing osdeps several times rather than installing all internal dependencies at once.

What do you think?