### PR TITLE
Add python package extension to activate python

### DIFF
--- a/lib/autoproj/autobuild.rb
+++ b/lib/autoproj/autobuild.rb
@@ -1,4 +1,5 @@
 require "autoproj/autobuild_extensions/package"
+require "autoproj/autobuild_extensions/python"
 require "autoproj/autobuild_extensions/archive_importer"
 require "autoproj/autobuild_extensions/git"
 require "autoproj/autobuild_extensions/svn"
@@ -15,4 +16,7 @@ Autobuild::Git.class_eval do
 end
 Autobuild::SVN.class_eval do
     prepend Autoproj::AutobuildExtensions::SVN
+end
+Autobuild::Python.class_eval do
+    prepend Autoproj::AutobuildExtensions::Python
 end

--- a/lib/autoproj/autobuild_extensions/dsl.rb
+++ b/lib/autoproj/autobuild_extensions/dsl.rb
@@ -226,8 +226,6 @@ def python_package(name, workspace: Autoproj.workspace)
     package_common(:python, name, workspace: workspace) do |pkg|
         pkg.internal_dependency "python"
         pkg.post_import do
-            Autoproj::Python.setup_python_configuration_options(ws: workspace)
-            Autoproj::Python.assert_python_activated(ws: workspace)
             pkg.depends_on "python-setuptools" if pkg.install_mode?
         end
         yield(pkg) if block_given?

--- a/lib/autoproj/autobuild_extensions/python.rb
+++ b/lib/autoproj/autobuild_extensions/python.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Autoproj
+    module AutobuildExtensions
+        # Extension for Autobuild::Python
+        module Python
+            def activate_python
+                Autoproj::Python.setup_python_configuration_options(ws: ws)
+                Autoproj::Python.assert_python_activated(ws: ws)
+            end
+
+            def update_environment
+                activate_python
+                super
+            end
+        end
+    end
+end

--- a/lib/autoproj/package_managers/pip_manager.rb
+++ b/lib/autoproj/package_managers/pip_manager.rb
@@ -27,12 +27,14 @@ module Autoproj
             end
 
             def guess_pip_program
-                unless ws.config.has_value_for?("USE_PYTHON")
-                    Autoproj::Python.setup_python_configuration_options(ws: ws)
-                end
-                Autoproj::Python.assert_python_activated(ws: ws)
+                activate_python
                 Autobuild.programs["pip"] = "pip" unless Autobuild.programs["pip"]
                 Autobuild.programs["pip"]
+            end
+
+            def activate_python
+                Autoproj::Python.setup_python_configuration_options(ws: ws)
+                Autoproj::Python.assert_python_activated(ws: ws)
             end
 
             def install(pips, filter_uptodate_packages: false, install_only: false)

--- a/lib/autoproj/python.rb
+++ b/lib/autoproj/python.rb
@@ -224,14 +224,14 @@ module Autoproj
 
             ws.osdep_suffixes << "python#{$1}" if version =~ /^([0-9]+)\./
 
-            rewrite_python_shims(bin, ws.prefix_dir)
-            rewrite_pip_shims(bin, ws.prefix_dir)
+            rewrite_python_shims(bin, ws.dot_autoproj_dir)
+            rewrite_pip_shims(bin, ws.dot_autoproj_dir)
             [bin, version]
         end
 
         def self.deactivate_python(ws: Autoproj.workspace)
-            remove_python_shims(ws.prefix_dir)
-            remove_pip_shims(ws.prefix_dir)
+            remove_python_shims(ws.dot_autoproj_dir)
+            remove_pip_shims(ws.dot_autoproj_dir)
             ws.config.reset("python_executable")
             ws.config.reset("python_version")
         end
@@ -279,8 +279,8 @@ module Autoproj
 
             if ws.config.get("USE_PYTHON")
                 unless ws.config.has_value_for?("python_executable")
-                    remove_python_shims(ws.prefix_dir)
-                    remove_pip_shims(ws.prefix_dir)
+                    remove_python_shims(ws.dot_autoproj_dir)
+                    remove_pip_shims(ws.dot_autoproj_dir)
                     python_bin, = auto_resolve_python(ws: ws)
                 end
 

--- a/test/autobuild_extensions/test_python.rb
+++ b/test/autobuild_extensions/test_python.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "autoproj/test"
+
+module Autoproj
+    describe "#update_environment" do
+        before do
+            @ws = ws_create
+            @pkg = ws_define_package :python, "pkg"
+            FileUtils.touch(File.join(@pkg.autobuild.srcdir, "setup.py"))
+        end
+        it "activates python before fetching python's user site path" do
+            flexmock(@pkg.autobuild).should_receive(:activate_python).once.ordered
+            flexmock(@pkg.autobuild).should_receive(:python_path).once.ordered
+            @pkg.autobuild.update_environment
+        end
+    end
+end

--- a/test/package_managers/test_pip.rb
+++ b/test/package_managers/test_pip.rb
@@ -26,6 +26,7 @@ module Autoproj
                 packages = %w[pkg0 pkg1 pkg2]
                 subprocess.should_receive(:run).explicitly
                           .with(any, any, "mypip", "install", "--user", "pkg0", "pkg1", "pkg2", any).once
+                ws.config.interactive = false
                 pip_manager.install(packages)
             end
 
@@ -36,11 +37,14 @@ module Autoproj
                 pip_manager.silent = false
                 subprocess.should_receive(:run).explicitly.never
                 flexmock($stdin).should_receive(:readline).once.and_return
+                ws.config.interactive = false
+                ws.config.set("USE_PYTHON", true, true)
                 pip_manager.install([["pkg0"]])
             end
 
             def test_no_use_python
-                ws.config.set("USE_PYTHON", false)
+                ws.config.set("USE_PYTHON", false, true)
+                ws.config.interactive = false
                 assert_raises(ConfigError) { pip_manager.guess_pip_program }
                 ws.config.set("USE_PYTHON", true)
             end
@@ -53,6 +57,12 @@ module Autoproj
                 assert_raises(ConfigError) { pip_manager.guess_pip_program }
                 ws.config.set("USE_PYTHON", true)
                 ws.config.interactive = interactive
+            end
+
+            def test_python_activation_with_config_already_set
+                ws.config.set("USE_PYTHON", true, true)
+                flexmock(pip_manager).should_receive(:activate_python).once
+                pip_manager.guess_pip_program
             end
         end
     end

--- a/test/test_python.rb
+++ b/test/test_python.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "autoproj/python"
 require "autoproj/test"
 

--- a/test/test_python.rb
+++ b/test/test_python.rb
@@ -141,12 +141,12 @@ module Autoproj
                 assert(@ws.config.has_value_for?("python_executable"))
                 assert(@ws.config.has_value_for?("python_version"))
 
-                python_bin = File.join(@ws.prefix_dir, "bin", "python")
+                python_bin = File.join(@ws.dot_autoproj_dir, "bin", "python")
                 assert(File.exist?(python_bin))
                 python_version = Autoproj::Python.get_python_version(python_bin)
                 assert(python_version == @ws.config.get("python_version"))
 
-                pip_bin = File.join(@ws.prefix_dir, "bin", "pip")
+                pip_bin = File.join(@ws.dot_autoproj_dir, "bin", "pip")
                 assert(File.exist?(pip_bin))
                 pip_version = Autoproj::Python.get_pip_version(pip_bin)
                 expected_pip_version = `#{python_bin} -c "import pip; print(pip.__version__)"`.strip


### PR DESCRIPTION
Follow-up from: https://github.com/rock-core/autoproj/pull/352

This also fixes a bug in the python activation code that was extracted from rock's package set where shims wouldn't be written if the user tried to set `USE_PYTHON` in his local configuration.