### PR TITLE
don't overwrie python shims during install

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -501,6 +501,7 @@ module Autoproj
                     bin_shim = File.join(shim_path, bin_name)
                     bin_script_lines = File.readlines(bin_script)
                     next if has_autoproj_preamble?(bin_script_lines)
+                    next unless ruby_script?(bin_script_lines)
 
                     File.open(bin_shim, "w") do |io|
                         if bin_name == "bundler" || bin_name == "bundle"
@@ -513,6 +514,10 @@ module Autoproj
                     end
                     FileUtils.chmod 0755, bin_shim
                 end
+            end
+
+            def self.ruby_script?(script_lines)
+                script_lines.first =~ /\#\s*!(.*ruby.*)/
             end
 
             def self.new_style_bundler_binstub?(script_lines)

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -501,6 +501,7 @@ module Autoproj
                     bin_shim = File.join(shim_path, bin_name)
                     bin_script_lines = File.readlines(bin_script)
                     next if has_autoproj_preamble?(bin_script_lines)
+                    next unless ruby_script?(bin_script_lines)
 
                     File.open(bin_shim, "w") do |io|
                         if bin_name == "bundler" || bin_name == "bundle"
@@ -513,6 +514,10 @@ module Autoproj
                     end
                     FileUtils.chmod 0755, bin_shim
                 end
+            end
+
+            def self.ruby_script?(script_lines)
+                script_lines.first =~ /\#\s*!(.*ruby.*)/
             end
 
             def self.new_style_bundler_binstub?(script_lines)

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -491,6 +491,7 @@ module Autoproj
                     bin_shim = File.join(shim_path, bin_name)
                     bin_script_lines = File.readlines(bin_script)
                     next if has_autoproj_preamble?(bin_script_lines)
+                    next unless ruby_script?(bin_script_lines)
 
                     File.open(bin_shim, "w") do |io|
                         if bin_name == "bundler" || bin_name == "bundle"
@@ -503,6 +504,10 @@ module Autoproj
                     end
                     FileUtils.chmod 0755, bin_shim
                 end
+            end
+
+            def self.ruby_script?(script_lines)
+                script_lines.first =~ /\#\s*!(.*ruby.*)/
             end
 
             def self.new_style_bundler_binstub?(script_lines)

--- a/test/ops/test_install.rb
+++ b/test/ops/test_install.rb
@@ -57,6 +57,31 @@ module Autoproj
                 end
             end
 
+            describe "npython shims" do
+                attr_reader :install_dir, :shared_dir, :python_shim, :pip_shim
+
+                before do
+                    @install_dir = make_tmpdir
+                    @shared_dir = make_tmpdir
+
+                    FileUtils.mkdir_p File.join(install_dir, ".autoproj", "bin")
+                    @python_shim = File.join(install_dir, ".autoproj", "bin", "python")
+                    @pip_shim = File.join(install_dir, ".autoproj", "bin", "pip")
+
+                    File.open(python_shim, "w") { |f| f.write("foobar") }
+                    File.open(pip_shim, "w") { |f| f.write("foobar") }
+
+                    @install_dir, = invoke_test_script(
+                        "install.sh", dir: install_dir, env: { "HOME" => shared_dir }
+                    )
+                end
+
+                it "does not overwrite python shims" do
+                    assert_equal "foobar", File.open(python_shim).read
+                    assert_equal "foobar", File.open(pip_shim).read
+                end
+            end
+
             describe "default shared gems location" do
                 attr_reader :shared_gem_home, :shared_dir, :install_dir
 


### PR DESCRIPTION
Fixes #357 

I had no idea autoproj would overwrite everything in `.autoproj/bin`.