### PR TITLE
fix: gem install location on Debian 11

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -173,7 +173,11 @@ module Autoproj
 
             # The user-wide place where RubyGems installs gems
             def dot_gem_dir
-                File.join(Gem.user_home, ".gem")
+                if Gem.respond_to?(:data_home) # Debian 11+
+                    File.join(Gem.data_home, "gem")
+                else
+                    File.join(Gem.user_home, ".gem")
+                end
             end
 
             # The version and platform-specific suffix under {#dot_gem_dir}

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -173,7 +173,11 @@ module Autoproj
 
             # The user-wide place where RubyGems installs gems
             def dot_gem_dir
-                File.join(Gem.user_home, ".gem")
+                if Gem.respond_to?(:data_home) # Debian 11+
+                    File.join(Gem.data_home, "gem")
+                else
+                    File.join(Gem.user_home, ".gem")
+                end
             end
 
             # The version and platform-specific suffix under {#dot_gem_dir}

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -163,7 +163,11 @@ module Autoproj
 
             # The user-wide place where RubyGems installs gems
             def dot_gem_dir
-                File.join(Gem.user_home, ".gem")
+                if Gem.respond_to?(:data_home) # Debian 11+
+                    File.join(Gem.data_home, "gem")
+                else
+                    File.join(Gem.user_home, ".gem")
+                end
             end
 
             # The version and platform-specific suffix under {#dot_gem_dir}


### PR DESCRIPTION
Debian is (in)famous for monkey-patching rubygems to make it follow
their standard. In this case, it moves the default gems install location
to the XDG data dir.

It defines Gem.data_home to indicate where things are going to be
installed. Use its presence as an indication that we're on Debian
and workaround the problem.