### PR TITLE
fix: not complete package_sets list during execution of init.rb

### DIFF
--- a/lib/autoproj/ops/configuration.rb
+++ b/lib/autoproj/ops/configuration.rb
@@ -626,12 +626,18 @@ module Autoproj
                 root_pkg_set.imports.each do |pkg_set|
                     pkg_set.explicit = true
                 end
+
+                # sort packages, main package is the last
                 package_sets = sort_package_sets_by_import_order(package_sets, root_pkg_set)
                 ws.manifest.reset_package_sets
                 package_sets.each do |pkg_set|
-                    ws.load_if_present(pkg_set, pkg_set.local_dir, "init.rb")
                     ws.manifest.register_package_set(pkg_set)
                 end
+
+                ws.manifest.each_package_set do |pkg_set|
+                    ws.load_if_present(pkg_set, pkg_set.local_dir, "init.rb")
+                end
+
                 failures
             end
         end


### PR DESCRIPTION
This is a fix for an issue, that we encountered after updating to autoproj 2.15.1.

In 2.15.1, the package set's init.rb was called when the manifest's package list was still not complete. 

In our case, package set's init.rb relies on the following information:

```
...
root_pkg_set = ws.manifest.main_package_set
...
```

Since the main package set was loaded as the last, "ws.manifest.main_package_set" is nil::Class at this point.

To resolve this issue, run each package's init.rb file after all package sets have been loaded into the manifest.