### PR TITLE
fix: reporting of cycles in Ops::Configuration

### DIFF
--- a/lib/autoproj.rb
+++ b/lib/autoproj.rb
@@ -63,7 +63,7 @@ require "utilrb/logger"
 
 module Autoproj
     class << self
-        attr_reader :logger
+        attr_accessor :logger
     end
     @logger = Logger.new(STDOUT)
     logger.level = Logger::WARN

--- a/lib/autoproj/package_set.rb
+++ b/lib/autoproj/package_set.rb
@@ -793,23 +793,6 @@ module Autoproj
             vcs
         end
 
-        # Recursively resolve imports for a given package set
-        def self.resolve_imports(pkg_set, parents = Set.new)
-            return Set.new if pkg_set.imports.empty?
-
-            updated_parents = parents | [pkg_set]
-
-            imports = pkg_set.imports.dup
-            pkg_set.imports.each do |p|
-                if parents.include?(p)
-                    raise "Cycling dependency between package sets encountered:" \
-                          "#{p.name} <--> #{pkg_set.name}"
-                end
-                imports.merge(resolve_imports(p, updated_parents))
-            end
-            imports
-        end
-
         # Enumerates the Autobuild::Package instances that are defined in this
         # source
         def each_package


### PR DESCRIPTION
Autoproj will still error out, but this time with a proper error message that explicitly displays the cycle, and refers to the package set order in the manifest.

Fixes #368