### PR TITLE
Don't depend on ignored packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :vscode do
     gem "debase", ">= 0.2.2.beta10"
     gem "pry"
     gem "pry-byebug"
-    gem "rubocop", ">= 0.6.0"
+    gem "rubocop", "~> 1.28.0"
     gem "rubocop-rock"
     gem "ruby-debug-ide", ">= 0.6.0"
     gem "solargraph"

--- a/lib/autoproj/autobuild_extensions/package.rb
+++ b/lib/autoproj/autobuild_extensions/package.rb
@@ -107,6 +107,8 @@ module Autoproj
 
                 pkg_autobuild, pkg_os = partition_package(name)
                 pkg_autobuild.each do |pkg|
+                    next if ws.manifest.ignored?(pkg)
+
                     super(pkg)
                 end
                 @os_packages.merge(pkg_os.to_set)

--- a/lib/autoproj/os_package_installer.rb
+++ b/lib/autoproj/os_package_installer.rb
@@ -185,7 +185,8 @@ So, what do you want ? (all, none or a comma-separated list of: os gem pip)
                 when "gem"  then modes << "gem"
                 when "pip"  then modes << "pip"
                 when "os"   then modes << "os"
-                when "none" then # rubocop:disable Lint/EmptyWhen
+                when "none" then
+                    # noop
                 else
                     if package_managers.key?(str)
                         modes << str

--- a/test/autobuild_extensions/test_package.rb
+++ b/test/autobuild_extensions/test_package.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "autoproj/test"
+require "autoproj/autobuild_extensions/package"
+require "autobuild/package"
+
+module Autobuild
+    describe Package do
+        describe "#depends_on" do
+            it "does not add a dependency on an ignored package" do
+                ws = ws_create
+                foo = ws_define_package :cmake, "foo"
+                bar = ws_define_package :cmake, "bar"
+
+                ws.manifest.ignore_package(foo)
+                bar.depends_on(foo)
+                assert bar.autobuild.dependencies.empty?
+            end
+        end
+    end
+end

--- a/test/test_system.rb
+++ b/test/test_system.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "autoproj/test"
+require "autoproj/cli/main"
+require "autoproj/cli/update"
+
+module Autoproj
+    describe "system tests" do
+        attr_reader :manifest_path
+        attr_reader :pkg_set_path
+        attr_reader :pkg_set
+        attr_reader :pkg
+
+        before do
+            ws_create
+
+            @pkg_set_path = File.join(ws.config_dir, "pkg_set0")
+            @pkg_set = ws_create_local_package_set(
+                "pkg_set0",
+                pkg_set_path,
+                source_data: source_data
+            )
+
+            ws_create_package_set_file(pkg_set, "test.autobuild", autobuild_contents)
+            @manifest_path = File.join(ws.config_dir, "manifest")
+            File.write(manifest_path, manifest_contents)
+            FileUtils.mkdir_p(File.join(ws.root_dir, "pkg0"))
+        end
+
+        def autobuild_contents
+            <<~EOFAUTOBUILD
+                import_package "pkg0"
+            EOFAUTOBUILD
+        end
+
+        def source_data
+            {
+                "version_control" =>
+                    [
+                        "pkg0" => nil,
+                        "type" => "local",
+                        "url" => File.join(ws.root_dir, "pkg0")
+                    ]
+            }
+        end
+
+        def manifest_contents
+            <<~EOFMANIFEST
+                package_sets:
+                    - pkg_set0
+
+                layout:
+                    - pkg0
+            EOFMANIFEST
+        end
+
+        describe "ignored packages" do
+            before do
+                File.open(File.join(pkg_set_path, "ignored.autobuild"), "w") do |f|
+                    content = <<~EOFCONTENT
+                        import_package "pkg1" do |pkg|
+                            package("pkg0").depends_on "pkg1"
+                        end
+
+                        Autoproj.workspace
+                                .current_package_set
+                                .add_version_control_entry(
+                                    "pkg1",
+                                    { type: "git", url: "https://remote" }
+                                )
+
+                        Autoproj.workspace.manifest.ignore_package("pkg1")
+                    EOFCONTENT
+
+                    f.write(content)
+                end
+            end
+
+            it "updates a workspace with ignored packages" do
+                in_ws do
+                    CLI::Main.start(%w[update --no-autoproj])
+                end
+            end
+
+            it "builds a workspace with ignored packages" do
+                in_ws do
+                    CLI::Main.start(%w[build])
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
Ignored packages are not imported and removed from selection during build (its Rake tasks are not created). However, they're still added as dependencies of other packages resulting in autobuild invoking Rake tasks that do not exist and a failure that a regular user is unlikely to make sense of.