### PR TITLE
fix: install without debase in GitHub actions as it breaks them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+    - name: Configure bundler without 'vscode'
+      run: bundle config set --local without vscode
     - name: Install dependencies
       run: bundle install
     - name: Run rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+    - name: Configure bundler without 'vscode'
+      run: bundle config set --local without vscode
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,15 @@ source "https://rubygems.org"
 
 gem "autobuild", git: "https://github.com/rock-core/autobuild", branch: "master"
 
+group :dev do
+    gem "rubocop", "~> 1.28.0"
+    gem "rubocop-rock"
+end
+
 group :vscode do
     gem "debase", ">= 0.2.2.beta10"
     gem "pry"
     gem "pry-byebug"
-    gem "rubocop", "~> 1.28.0"
-    gem "rubocop-rock"
     gem "ruby-debug-ide", ">= 0.6.0"
     gem "solargraph"
 end


### PR DESCRIPTION
This is an error under bundler, which makes our CI actions fail.