### PR TITLE
fix: filter out gems that have the same prefix than a precompiled gem

### DIFF
--- a/lib/autoproj/ops/cache.rb
+++ b/lib/autoproj/ops/cache.rb
@@ -166,6 +166,7 @@ module Autoproj
                 failed = []
                 compile.each do |gem_name, artifacts: []|
                     Dir.glob(File.join(cache_dir, "#{gem_name}*.gem")) do |gem|
+                        next unless /^#{gem_name}-\d/.match?(File.basename(gem))
                         next if gem.end_with?(platform_suffix)
 
                         gem_basename = File.basename(gem, ".gem")


### PR DESCRIPTION
E.g. do not precompile ffi-rzmq-core when 'ffi' is meant to be compiled