### PR TITLE
fix: force bundler 2.4 to pick the "right" versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ task "bootstrap" do
     %w[bootstrap install].each do |install_script|
         bootstrap_code = File.read(File.join(Dir.pwd, "bin", "autoproj_#{install_script}.in"))
                              .gsub("require 'autoproj/ops/install'", autoproj_ops_install)
+                             .gsub('#{Autoproj::VERSION}', Autoproj::VERSION) # rubocop:disable Lint/InterpolationCheck
         File.open(File.join(Dir.pwd, "bin", "autoproj_#{install_script}"), "w") do |io|
             io.write bootstrap_code
         end

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -323,6 +323,7 @@ module Autoproj
                            "when reinstalling an existing autoproj workspace, do not "\
                            "use the config in .autoproj/ as seed" do
                         @config.clear
+                        @config["bundler_version"] = Install.default_bundler_version
                     end
                     opt.on "--seed-config=PATH", String, "path to a seed file that "\
                                                          "should be used to initialize the configuration" do |path|
@@ -756,9 +757,15 @@ require 'bundler/setup'
                 end
 
                 @config = config
+                @config["bundler_version"] ||= self.class.default_bundler_version
+
                 %w[gems_install_path prefer_indep_over_os_packages].each do |flag|
                     instance_variable_set "@#{flag}", config.fetch(flag, false)
                 end
+            end
+
+            def self.default_bundler_version
+                "2.3.6" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
             end
 
             def save_config

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -269,7 +269,7 @@ module Autoproj
             # @param [String] autoproj_version a constraint on the autoproj version
             #   that should be used
             # @return [String]
-            def default_gemfile_contents(autoproj_version = ">= 2.0.0")
+            def default_gemfile_contents(autoproj_version = ">= 2.16.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -272,8 +272,7 @@ module Autoproj
             def default_gemfile_contents(autoproj_version = ">= 2.0.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
-                 "gem \"autoproj\", \"#{autoproj_version}\"",
-                 "gem \"utilrb\", \">= 3.0.1\""].join("\n")
+                 "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
             def add_seed_config(path)

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -323,6 +323,7 @@ module Autoproj
                            "when reinstalling an existing autoproj workspace, do not "\
                            "use the config in .autoproj/ as seed" do
                         @config.clear
+                        @config["bundler_version"] = Install.default_bundler_version
                     end
                     opt.on "--seed-config=PATH", String, "path to a seed file that "\
                                                          "should be used to initialize the configuration" do |path|
@@ -756,9 +757,15 @@ require 'bundler/setup'
                 end
 
                 @config = config
+                @config["bundler_version"] ||= self.class.default_bundler_version
+
                 %w[gems_install_path prefer_indep_over_os_packages].each do |flag|
                     instance_variable_set "@#{flag}", config.fetch(flag, false)
                 end
+            end
+
+            def self.default_bundler_version
+                "2.3.6" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
             end
 
             def save_config

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -269,7 +269,7 @@ module Autoproj
             # @param [String] autoproj_version a constraint on the autoproj version
             #   that should be used
             # @return [String]
-            def default_gemfile_contents(autoproj_version = ">= 2.0.0")
+            def default_gemfile_contents(autoproj_version = ">= 2.16.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -272,8 +272,7 @@ module Autoproj
             def default_gemfile_contents(autoproj_version = ">= 2.0.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
-                 "gem \"autoproj\", \"#{autoproj_version}\"",
-                 "gem \"utilrb\", \">= 3.0.1\""].join("\n")
+                 "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
             def add_seed_config(path)

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -313,6 +313,7 @@ module Autoproj
                            "when reinstalling an existing autoproj workspace, do not "\
                            "use the config in .autoproj/ as seed" do
                         @config.clear
+                        @config["bundler_version"] = Install.default_bundler_version
                     end
                     opt.on "--seed-config=PATH", String, "path to a seed file that "\
                                                          "should be used to initialize the configuration" do |path|
@@ -746,9 +747,15 @@ require 'bundler/setup'
                 end
 
                 @config = config
+                @config["bundler_version"] ||= self.class.default_bundler_version
+
                 %w[gems_install_path prefer_indep_over_os_packages].each do |flag|
                     instance_variable_set "@#{flag}", config.fetch(flag, false)
                 end
+            end
+
+            def self.default_bundler_version
+                "2.3.6" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
             end
 
             def save_config

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -259,11 +259,10 @@ module Autoproj
             # @param [String] autoproj_version a constraint on the autoproj version
             #   that should be used
             # @return [String]
-            def default_gemfile_contents(autoproj_version = ">= 2.0.0")
+            def default_gemfile_contents(autoproj_version = ">= #{Autoproj::VERSION}")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
-                 "gem \"autoproj\", \"#{autoproj_version}\"",
-                 "gem \"utilrb\", \">= 3.0.1\""].join("\n")
+                 "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
             def add_seed_config(path)

--- a/test/ops/test_install.rb
+++ b/test/ops/test_install.rb
@@ -260,7 +260,7 @@ module Autoproj
 
                     config_yml = File.join(dir, ".autoproj", "config.yml")
                     config = YAML.safe_load(File.read(config_yml))
-                    config.delete("bundler_version")
+                    config["bundler_version"] = Autoproj::Ops::Install.default_bundler_version
                     File.open(config_yml, "w") do |io|
                         YAML.dump(config, io)
                     end


### PR DESCRIPTION
Cf https://github.com/rubygems/rubygems/issues/6226 for the underlying problem

The `utilrb` version constraint is an artifact long unneeded. I removed it to "free" bundler to install the latest version of autoproj. In addition, installation now adds a `>= $CURRENT_AUTOPROJ_VERSION` constraint to make sure it won't
get downgraded.