### PR TITLE
Ensure that path is absolute

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -97,7 +97,9 @@ module Autoproj
                 @ruby_executable = config["ruby_executable"]
                 @local = false
 
-                install_gems_in_gem_user_dir unless @gems_install_path
+                @gems_install_path ||= default_gems_install_path
+                @gems_install_path = File.expand_path(@gems_install_path)
+
                 env["GEM_HOME"] = [gems_gem_home]
                 env["GEM_PATH"] = [gems_gem_home]
             end
@@ -171,24 +173,17 @@ module Autoproj
             # (see #local?)
             attr_writer :local
 
-            # The user-wide place where RubyGems installs gems
-            def self.dot_gem_dir
-                if Gem.respond_to?(:data_home) # Debian 11+
-                    File.join(Gem.data_home, "gem")
-                else
-                    File.join(Gem.user_home, ".gem")
-                end
-            end
-
-            # The version and platform-specific suffix under {#dot_gem_dir}
+            # The version and platform-specific suffix
             #
             # This is also the suffix used by bundler to install gems
             def self.gems_path_suffix
-                @gems_path_suffix ||=
-                    Pathname
-                    .new(Gem.user_dir)
-                    .relative_path_from(Pathname.new(dot_gem_dir))
-                    .to_s
+                return @gems_path_suffix if @gem_path_suffix
+
+                parts = [Gem.ruby_engine]
+                unless RbConfig::CONFIG["ruby_version"].empty?
+                    parts << RbConfig::CONFIG["ruby_version"]
+                end
+                @gems_path_suffix = File.join parts
             end
 
             # The path into which the workspace's gems should be installed
@@ -219,21 +214,21 @@ module Autoproj
                 end
             end
 
-            # Install autoproj in Gem's default user dir
-            def install_gems_in_gem_user_dir
+            # Get autoproj's default path for installing gems
+            def default_gems_install_path
                 xdg_default_gem_path = xdg_var("XDG_DATA_HOME",
                                                File.join(Dir.home, ".local", "share", "autoproj", "gems"))
                 default_gem_path = File.join(
                     Dir.home, ".autoproj", "gems"
                 )
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+
+                if File.directory?(xdg_default_gem_path)
+                    xdg_default_gem_path
+                elsif File.directory?(default_gem_path)
+                    default_gem_path
+                else
+                    xdg_default_gem_path
+                end
             end
 
             # Whether autoproj should prefer OS-independent packages over their
@@ -296,11 +291,12 @@ module Autoproj
                         @gem_source = url
                     end
                     opt.on "--gems-path=PATH", "install gems under this path instead "\
-                                               "of ~/.autoproj/gems" do |path|
-                        self.gems_install_path = path
+                                               "of #{default_gems_install_path} (do not use with --public-gems)" do |path|
+                        @gems_install_path = path
                     end
-                    opt.on "--public-gems", "install gems in the default gem location" do
-                        install_gems_in_gem_user_dir
+                    opt.on "--public-gems", "install gems in the default gem location: #{default_gems_install_path}"\
+                                            " (do not use with --gems-path)" do
+                        @gems_install_path = default_gems_install_path
                     end
                     opt.on "--bundler-version=VERSION_CONSTRAINT", String, "use the provided "\
                                                                            "string as a version constraint for bundler" do |version|

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -97,7 +97,9 @@ module Autoproj
                 @ruby_executable = config["ruby_executable"]
                 @local = false
 
-                install_gems_in_gem_user_dir unless @gems_install_path
+                @gems_install_path ||= default_gems_install_path
+                @gems_install_path = File.expand_path(@gems_install_path)
+
                 env["GEM_HOME"] = [gems_gem_home]
                 env["GEM_PATH"] = [gems_gem_home]
             end
@@ -171,24 +173,17 @@ module Autoproj
             # (see #local?)
             attr_writer :local
 
-            # The user-wide place where RubyGems installs gems
-            def self.dot_gem_dir
-                if Gem.respond_to?(:data_home) # Debian 11+
-                    File.join(Gem.data_home, "gem")
-                else
-                    File.join(Gem.user_home, ".gem")
-                end
-            end
-
-            # The version and platform-specific suffix under {#dot_gem_dir}
+            # The version and platform-specific suffix
             #
             # This is also the suffix used by bundler to install gems
             def self.gems_path_suffix
-                @gems_path_suffix ||=
-                    Pathname
-                    .new(Gem.user_dir)
-                    .relative_path_from(Pathname.new(dot_gem_dir))
-                    .to_s
+                return @gems_path_suffix if @gem_path_suffix
+
+                parts = [Gem.ruby_engine]
+                unless RbConfig::CONFIG["ruby_version"].empty?
+                    parts << RbConfig::CONFIG["ruby_version"]
+                end
+                @gems_path_suffix = File.join parts
             end
 
             # The path into which the workspace's gems should be installed
@@ -219,21 +214,21 @@ module Autoproj
                 end
             end
 
-            # Install autoproj in Gem's default user dir
-            def install_gems_in_gem_user_dir
+            # Get autoproj's default path for installing gems
+            def default_gems_install_path
                 xdg_default_gem_path = xdg_var("XDG_DATA_HOME",
                                                File.join(Dir.home, ".local", "share", "autoproj", "gems"))
                 default_gem_path = File.join(
                     Dir.home, ".autoproj", "gems"
                 )
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+
+                if File.directory?(xdg_default_gem_path)
+                    xdg_default_gem_path
+                elsif File.directory?(default_gem_path)
+                    default_gem_path
+                else
+                    xdg_default_gem_path
+                end
             end
 
             # Whether autoproj should prefer OS-independent packages over their
@@ -296,11 +291,12 @@ module Autoproj
                         @gem_source = url
                     end
                     opt.on "--gems-path=PATH", "install gems under this path instead "\
-                                               "of ~/.autoproj/gems" do |path|
-                        self.gems_install_path = path
+                                               "of #{default_gems_install_path} (do not use with --public-gems)" do |path|
+                        @gems_install_path = path
                     end
-                    opt.on "--public-gems", "install gems in the default gem location" do
-                        install_gems_in_gem_user_dir
+                    opt.on "--public-gems", "install gems in the default gem location: #{default_gems_install_path}"\
+                                            " (do not use with --gems-path)" do
+                        @gems_install_path = default_gems_install_path
                     end
                     opt.on "--bundler-version=VERSION_CONSTRAINT", String, "use the provided "\
                                                                            "string as a version constraint for bundler" do |version|

--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -268,11 +268,6 @@ module Autoproj
             set("parallel_import_level", level)
         end
 
-        # The user-wide place where RubyGems installs gems
-        def self.dot_gem_dir
-            Ops::Install.dot_gem_dir
-        end
-
         # The Ruby platform and version-specific subdirectory used by bundler and rubygem
         def self.gems_path_suffix
             Ops::Install.gems_path_suffix

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -87,7 +87,9 @@ module Autoproj
                 @ruby_executable = config["ruby_executable"]
                 @local = false
 
-                install_gems_in_gem_user_dir unless @gems_install_path
+                @gems_install_path ||= default_gems_install_path
+                @gems_install_path = File.expand_path(@gems_install_path)
+
                 env["GEM_HOME"] = [gems_gem_home]
                 env["GEM_PATH"] = [gems_gem_home]
             end
@@ -161,24 +163,17 @@ module Autoproj
             # (see #local?)
             attr_writer :local
 
-            # The user-wide place where RubyGems installs gems
-            def self.dot_gem_dir
-                if Gem.respond_to?(:data_home) # Debian 11+
-                    File.join(Gem.data_home, "gem")
-                else
-                    File.join(Gem.user_home, ".gem")
-                end
-            end
-
-            # The version and platform-specific suffix under {#dot_gem_dir}
+            # The version and platform-specific suffix
             #
             # This is also the suffix used by bundler to install gems
             def self.gems_path_suffix
-                @gems_path_suffix ||=
-                    Pathname
-                    .new(Gem.user_dir)
-                    .relative_path_from(Pathname.new(dot_gem_dir))
-                    .to_s
+                return @gems_path_suffix if @gem_path_suffix
+
+                parts = [Gem.ruby_engine]
+                unless RbConfig::CONFIG["ruby_version"].empty?
+                    parts << RbConfig::CONFIG["ruby_version"]
+                end
+                @gems_path_suffix = File.join parts
             end
 
             # The path into which the workspace's gems should be installed
@@ -209,21 +204,21 @@ module Autoproj
                 end
             end
 
-            # Install autoproj in Gem's default user dir
-            def install_gems_in_gem_user_dir
+            # Get autoproj's default path for installing gems
+            def default_gems_install_path
                 xdg_default_gem_path = xdg_var("XDG_DATA_HOME",
                                                File.join(Dir.home, ".local", "share", "autoproj", "gems"))
                 default_gem_path = File.join(
                     Dir.home, ".autoproj", "gems"
                 )
-                @gems_install_path =
-                    if File.directory?(xdg_default_gem_path)
-                        xdg_default_gem_path
-                    elsif File.directory?(default_gem_path)
-                        default_gem_path
-                    else
-                        xdg_default_gem_path
-                    end
+
+                if File.directory?(xdg_default_gem_path)
+                    xdg_default_gem_path
+                elsif File.directory?(default_gem_path)
+                    default_gem_path
+                else
+                    xdg_default_gem_path
+                end
             end
 
             # Whether autoproj should prefer OS-independent packages over their
@@ -286,11 +281,12 @@ module Autoproj
                         @gem_source = url
                     end
                     opt.on "--gems-path=PATH", "install gems under this path instead "\
-                                               "of ~/.autoproj/gems" do |path|
-                        self.gems_install_path = path
+                                               "of #{default_gems_install_path} (do not use with --public-gems)" do |path|
+                        @gems_install_path = path
                     end
-                    opt.on "--public-gems", "install gems in the default gem location" do
-                        install_gems_in_gem_user_dir
+                    opt.on "--public-gems", "install gems in the default gem location: #{default_gems_install_path}"\
+                                            " (do not use with --gems-path)" do
+                        @gems_install_path = default_gems_install_path
                     end
                     opt.on "--bundler-version=VERSION_CONSTRAINT", String, "use the provided "\
                                                                            "string as a version constraint for bundler" do |version|


### PR DESCRIPTION
"find_bundler" failed to properly match two paths, since at least one contained relative references.

This call ensures that also relative intermediate references are being removed.

That should also fix https://github.com/rock-core/autoproj/issues/377 for Ruby 3.0


