### PR TITLE
add option to disable the .git suffix

### DIFF
--- a/lib/autoproj/git_server_configuration.rb
+++ b/lib/autoproj/git_server_configuration.rb
@@ -101,8 +101,8 @@ module Autoproj
         end
 
         Autoproj.add_source_handler name.downcase do |url, private: false, **vcs_options|
-            if add_suffix
-                url += ".git" if url !~ /\.git$/
+            if add_suffix && url !~ /\.git$/
+                url += ".git"
             end
             url = "/#{url}" if url !~ /^\//
 

--- a/lib/autoproj/git_server_configuration.rb
+++ b/lib/autoproj/git_server_configuration.rb
@@ -103,6 +103,7 @@ module Autoproj
         Autoproj.add_source_handler name.downcase do |url, private: false, **vcs_options|
             if add_suffix
                 url += ".git" if url !~ /\.git$/
+            end
             url = "/#{url}" if url !~ /^\//
 
             unless GIT_SERVER_CONFIG_VARS.all? { |v| config.has_value_for?("#{name}#{v}") }

--- a/lib/autoproj/git_server_configuration.rb
+++ b/lib/autoproj/git_server_configuration.rb
@@ -73,7 +73,8 @@ module Autoproj
         disabled_methods: [],
         config: Autoproj.config,
         fallback_to_http: nil,
-        lazy: false)
+        lazy: false,
+        add_suffix: true)
 
         disabled_methods = Array(disabled_methods)
 
@@ -100,7 +101,8 @@ module Autoproj
         end
 
         Autoproj.add_source_handler name.downcase do |url, private: false, **vcs_options|
-            url += ".git" if url !~ /\.git$/
+            if add_suffix
+                url += ".git" if url !~ /\.git$/
             url = "/#{url}" if url !~ /^\//
 
             unless GIT_SERVER_CONFIG_VARS.all? { |v| config.has_value_for?("#{name}#{v}") }

--- a/lib/autoproj/git_server_configuration.rb
+++ b/lib/autoproj/git_server_configuration.rb
@@ -101,9 +101,7 @@ module Autoproj
         end
 
         Autoproj.add_source_handler name.downcase do |url, private: false, **vcs_options|
-            if add_suffix && url !~ /\.git$/
-                url += ".git"
-            end
+            url += ".git" if add_suffix && url !~ /\.git$/
             url = "/#{url}" if url !~ /^\//
 
             unless GIT_SERVER_CONFIG_VARS.all? { |v| config.has_value_for?("#{name}#{v}") }


### PR DESCRIPTION
Hello Sylvain @doudou !

Here is the commit to the issue https://github.com/rock-core/autoproj/issues/400.
I thought, there is only one possible suffix for git repositories, .git. So I have modified your advice from the issue, and added the option to disable the suffix without the possibility to modify the suffix itself.
So at the end, the user can leave everything how it is, and per default .git will be added to the repos. Or use add_suffix: false to get the repository urls without .git ending. 

I tested it on my local setup. Where I had two git server configurations: one without add_suffix option and one with add_suffix: false. 

