### PR TITLE
Add error message when the package_sets part in the manifest is not an Array

### DIFF
--- a/lib/autoproj/local_package_set.rb
+++ b/lib/autoproj/local_package_set.rb
@@ -81,6 +81,9 @@ module Autoproj
             manifest_data = Autoproj.in_file(manifest_path, Autoproj::YAML_LOAD_ERROR) do
                 YAML.load(File.read(manifest_path)) || Hash.new
             end
+            if !manifest_data["package_sets"].is_a?(Array)
+                raise SyntaxError.new "The package_sets field in your manifest file is not an array, check your YAML syntax"
+            end
             description["imports"] = description["imports"]
                                      .concat(manifest_data["package_sets"] || Array.new)
             description["name"] = name


### PR DESCRIPTION
When the package_sets part in the manifest file in malformed like this (missing dash before github):
```yaml
package_sets:
   github: rock-core/package_set
```
Only a cryptic error message is displayed without reference to the manifest file: `local_package_set.rb:93:in `concat': no implicit conversion of Hash into Array (TypeError)`

This adds a proper message that points to the source of the problem: `local_package_set.rb:90:in `raw_description_file': The package_sets field in your manifest file is not an array, check your YAML syntax (SyntaxError)`

