### PR TITLE
Fix yaml safe load

### DIFF
--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -264,14 +264,22 @@ module Autoproj
             # @param [String] autoproj_version a constraint on the autoproj version
             #   that should be used
             # @return [String]
-            def default_gemfile_contents(autoproj_version = ">= 2.16.0")
+            def default_gemfile_contents(autoproj_version = ">= 2.17.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
+            def load_yaml(contents)
+                if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0")
+                    YAML.safe_load(contents, permitted_classes: [Symbol])
+                else
+                    YAML.safe_load(contents, [Symbol])
+                end
+            end
+
             def add_seed_config(path)
-                @config.merge!(YAML.safe_load(File.read(path), [Symbol]))
+                @config.merge!(load_yaml(File.read(path)))
             end
 
             # Parse the provided command line options and returns the non-options

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -264,14 +264,22 @@ module Autoproj
             # @param [String] autoproj_version a constraint on the autoproj version
             #   that should be used
             # @return [String]
-            def default_gemfile_contents(autoproj_version = ">= 2.16.0")
+            def default_gemfile_contents(autoproj_version = ">= 2.17.0")
                 ["source \"#{gem_source}\"",
                  "ruby \"#{RUBY_VERSION}\" if respond_to?(:ruby)",
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
+            def load_yaml(contents)
+                if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0")
+                    YAML.safe_load(contents, permitted_classes: [Symbol])
+                else
+                    YAML.safe_load(contents, [Symbol])
+                end
+            end
+
             def add_seed_config(path)
-                @config.merge!(YAML.safe_load(File.read(path), [Symbol]))
+                @config.merge!(load_yaml(File.read(path)))
             end
 
             # Parse the provided command line options and returns the non-options

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -260,8 +260,16 @@ module Autoproj
                  "gem \"autoproj\", \"#{autoproj_version}\""].join("\n")
             end
 
+            def load_yaml(contents)
+                if Gem::Version.new(Psych::VERSION) >= Gem::Version.new("3.1.0")
+                    YAML.safe_load(contents, permitted_classes: [Symbol])
+                else
+                    YAML.safe_load(contents, [Symbol])
+                end
+            end
+
             def add_seed_config(path)
-                @config.merge!(YAML.safe_load(File.read(path), [Symbol]))
+                @config.merge!(load_yaml(File.read(path)))
             end
 
             # Parse the provided command line options and returns the non-options

--- a/test/ops/test_install.rb
+++ b/test/ops/test_install.rb
@@ -228,35 +228,35 @@ module Autoproj
                 it "picks a specific bundler version as passed in the seed config" do
                     seed_config_path = File.join(make_tmpdir, "config.yml")
                     File.open(seed_config_path, "w") do |io|
-                        YAML.dump({ "bundler_version" => "2.0.1" }, io)
+                        YAML.dump({ "bundler_version" => "2.3.5" }, io)
                     end
 
                     dir, = invoke_test_script(
                         "install.sh", "--seed-config", seed_config_path
                     )
-                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    assert_match(/2.3.5/, `#{dir}/.autoproj/bin/bundle --version`.strip)
                 end
 
                 it "picks a specific bundler version as passed on the command line" do
-                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.0.1")
-                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.3.5")
+                    assert_match(/2.3.5/, `#{dir}/.autoproj/bin/bundle --version`.strip)
                 end
 
                 it "pins the install to the selected bundler version" do
-                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.0.1")
+                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.3.5")
                     `#{dir}/.autoproj/bin/autoproj update`
-                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    assert_match(/2.3.5/, `#{dir}/.autoproj/bin/bundle --version`.strip)
                 end
 
                 it "can pin a bundler version on an existing bootstrap" do
                     dir, = invoke_test_script("install.sh")
-                    refute_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
-                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.0.1")
-                    assert_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    refute_match(/2.3.5/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.3.26")
+                    assert_match(/2.3.26/, `#{dir}/.autoproj/bin/bundle --version`.strip)
                 end
 
                 it "can unpin a bundler version after the bootstrap" do
-                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.0.1")
+                    dir, = invoke_test_script("install.sh", "--bundler-version", "2.3.5")
 
                     config_yml = File.join(dir, ".autoproj", "config.yml")
                     config = YAML.safe_load(File.read(config_yml))
@@ -265,7 +265,7 @@ module Autoproj
                         YAML.dump(config, io)
                     end
                     `#{dir}/.autoproj/bin/autoproj update`
-                    refute_match(/2.0.1/, `#{dir}/.autoproj/bin/bundle --version`.strip)
+                    refute_match(/2.3.5/, `#{dir}/.autoproj/bin/bundle --version`.strip)
                 end
             end
         end


### PR DESCRIPTION
Passing whitelisted classes to `YAML$safe_load` as a positional argument has been deprecated in Psych v3.1.0 (Ruby v2.7.8) and completely removed in v4.0.3 (Ruby v3.1.0)