### PR TITLE
fix: allow to disable osdeps overload warnings

### DIFF
--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -370,6 +370,28 @@ module Autoproj
             set("prefix", path, true)
         end
 
+        # Whether Autoproj should warn if a package set overrides the osdep of
+        # another
+        #
+        # It is true for historical reasons. Set this to false in your
+        # workspace's init.rb for the new behavior
+        #
+        # @see osdeps_warn_overrides=
+        def osdeps_warn_overrides?
+            get "osdeps_warn_overrides", true
+        end
+
+        # Sets whether Autoproj should warn if a package set overrides the osdep
+        # of another
+        #
+        # It is true for historical reasons. Set this to false in your
+        # workspace's init.rb for the new behavior
+        #
+        # @see osdeps_warn_overrides?
+        def osdeps_warn_overrides=(flag)
+            set "osdeps_warn_overrides", flag
+        end
+
         # The directory in which packages will be installed.
         #
         # If it is a relative path, it is relative to the root dir of the

--- a/lib/autoproj/manifest.rb
+++ b/lib/autoproj/manifest.rb
@@ -185,7 +185,7 @@ module Autoproj
         # build nothing) and no layout at all
         attr_predicate :has_layout?
 
-        def initialize(ws, os_package_resolver: OSPackageResolver.new)
+        def initialize(ws, os_package_resolver: OSPackageResolver.new(ws))
             @ws = ws
             @vcs = VCSDefinition.none
             @file = nil

--- a/lib/autoproj/os_package_resolver.rb
+++ b/lib/autoproj/os_package_resolver.rb
@@ -4,7 +4,7 @@ require "json"
 module Autoproj
     # Manager for packages provided by external package managers
     class OSPackageResolver
-        def self.load(file, suffixes: [], **options)
+        def self.load(ws, file, suffixes: [], **options)
             unless File.file?(file)
                 raise ArgumentError, "no such file or directory #{file}"
             end
@@ -19,7 +19,7 @@ module Autoproj
                     ArgumentError
                 end
 
-            result = new(**options)
+            result = new(ws, **options)
             candidates.each do |file_candidate|
                 next unless File.file?(file_candidate)
 
@@ -32,7 +32,9 @@ module Autoproj
                                            "#{e.message}", e.backtrace
                 end
 
-                result.merge(new(data, file_candidate, **options))
+                result.merge(
+                    new(ws, data, file_candidate, **options)
+                )
             end
             result
         end
@@ -49,18 +51,18 @@ module Autoproj
         end
 
         AUTOPROJ_OSDEPS = File.join(__dir__, "default.osdeps")
-        def self.load_default
+        def self.load_default(ws)
             file = ENV["AUTOPROJ_DEFAULT_OSDEPS"] || AUTOPROJ_OSDEPS
             unless File.file?(file)
                 Autoproj.warn "#{file} (from AUTOPROJ_DEFAULT_OSDEPS) is not a file, "\
                               "falling back to #{AUTOPROJ_OSDEPS}"
                 file = AUTOPROJ_OSDEPS
             end
-            load(file)
+            load(ws, file)
         end
 
         def load_default
-            merge(self.class.load_default)
+            merge(self.class.load_default(@ws))
         end
 
         PACKAGE_MANAGERS = OSPackageInstaller::PACKAGE_MANAGERS.keys
@@ -140,10 +142,13 @@ module Autoproj
 
         # The Gem::SpecFetcher object that should be used to query RubyGems, and
         # install RubyGems packages
-        def initialize(defs = Hash.new, file = nil,
+        def initialize(
+            ws, defs = {}, file = nil,
             operating_system: nil,
             package_managers: PACKAGE_MANAGERS.dup,
-            os_package_manager: nil)
+            os_package_manager: nil
+        )
+            @ws = ws
             @definitions = defs.to_hash
             @resolve_package_cache = Hash.new
             @all_definitions = Hash.new { |h, k| h[k] = Array.new }

--- a/lib/autoproj/os_package_resolver.rb
+++ b/lib/autoproj/os_package_resolver.rb
@@ -210,7 +210,9 @@ module Autoproj
         # takes precedence
         def merge(info, suffixes: [])
             @definitions = definitions.merge(info.definitions) do |h, v1, v2|
-                warn_about_merge_collisions(info, suffixes, h, v1, v2) if v1 != v2
+                if v1 != v2 && ws.config.osdeps_warn_overrides?
+                    warn_about_merge_collisions(info, suffixes, h, v1, v2)
+                end
                 v2
             end
             invalidate_resolve_package_cache

--- a/lib/autoproj/package_set.rb
+++ b/lib/autoproj/package_set.rb
@@ -167,6 +167,7 @@ module Autoproj
             @name = name
             @os_repository_resolver = OSRepositoryResolver.new
             @os_package_resolver = OSPackageResolver.new(
+                ws,
                 operating_system: ws.os_package_resolver.operating_system,
                 package_managers: ws.os_package_resolver.package_managers,
                 os_package_manager: ws.os_package_resolver.os_package_manager
@@ -191,7 +192,7 @@ module Autoproj
         # Load a new osdeps file for this package set
         def load_osdeps(file, **options)
             new_osdeps = OSPackageResolver.load(
-                file,
+                @ws, file,
                 suffixes: ws.osdep_suffixes,
                 **options
             )

--- a/lib/autoproj/test.rb
+++ b/lib/autoproj/test.rb
@@ -312,6 +312,7 @@ module Autoproj
 
         def ws_create_os_package_resolver
             @ws_os_package_resolver = OSPackageResolver.new(
+                @ws,
                 operating_system: [["test_os_family"], ["test_os_version"]],
                 package_managers: ws_package_managers.keys,
                 os_package_manager: "os"

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -52,7 +52,7 @@ module Autoproj
         attr_reader :osdep_suffixes
 
         def initialize(root_dir,
-            os_package_resolver: OSPackageResolver.new,
+            os_package_resolver: OSPackageResolver.new(self),
             package_managers: OSPackageInstaller::PACKAGE_MANAGERS,
             os_repository_resolver: OSRepositoryResolver.new(
                 operating_system: os_package_resolver.operating_system


### PR DESCRIPTION
It's a common usage pattern, and `autoproj show` allows to see it.