### PR TITLE
Ignore ruby32 by default (same as for lower ruby versions)

### DIFF
--- a/lib/autoproj/default.osdeps
+++ b/lib/autoproj/default.osdeps
@@ -101,6 +101,10 @@ ruby27:
 ruby30:
   default: ignore # we assume that if the user has a ruby 3.0 runtime, it is usable
 
+ruby32:
+  default: ignore # we assume that if the user has a ruby 3.0 runtime, it is usable
+
+
 build-essential:
   debian,ubuntu: build-essential
   gentoo: ignore


### PR DESCRIPTION
This is required for Ubuntu 24.04 compatibility. Without this, one gets errors like

```
${SOME_PACKAGE} lists 'ruby' as dependency, but it is neither a normal package nor an osdeps package. osdeps reports: cannot resolve ruby: ruby is not an osdep and it cannot be resolved as a source package
```

Maybe there is a more future-proof way to fix this (i.e., not requiring to add an entry for every new version)

Somewhat related: https://github.com/orocos-toolchain/autoproj/pull/38