### PR TITLE
allow installing ruby shims in a separate prefix

### DIFF
--- a/lib/autoproj/configuration.rb
+++ b/lib/autoproj/configuration.rb
@@ -436,6 +436,22 @@ module Autoproj
             set("separate_prefixes", flag, true)
         end
 
+        # Returns true if Ruby shims should be installed in a separate prefix
+        #
+        # The default is false (disabled)
+        #
+        # @return [Boolean]
+        def isolate_ruby_shims?
+            get("isolate_ruby_shims", false)
+        end
+
+        # Controls whether Ruby shims should be in a separate prefix
+        #
+        # @see isolate_shims?
+        def isolate_ruby_shims=(flag)
+            set("isolate_ruby_shims", flag, true)
+        end
+
         # Returns true if packages and prefixes should be auto-generated, based
         # on the SHA of the package names. This is meant to be used for build
         # services that want to check that dependencies are properly set

--- a/lib/autoproj/workspace.rb
+++ b/lib/autoproj/workspace.rb
@@ -405,7 +405,14 @@ module Autoproj
                 install_suffix = match[1]
             end
 
-            bindir = File.join(prefix_dir, "bin")
+            prefixdir =
+                if config.isolate_ruby_shims?
+                    File.join(prefix_dir, "autoproj")
+                else
+                    prefix_dir
+                end
+
+            bindir = File.join(prefixdir, "bin")
             FileUtils.mkdir_p bindir
             env.add "PATH", bindir
 

--- a/test/test_workspace.rb
+++ b/test/test_workspace.rb
@@ -151,6 +151,22 @@ module Autoproj
                 ws.should_receive(:load_main_initrb).once.globally.ordered
                 ws.setup
             end
+
+            it "creates ruby shims in the main prefixdir" do
+                ws.setup
+                %w[gem irb ruby].each do |shim|
+                    assert_equal File.join(ws.prefix_dir, "bin", shim), ws.which(shim)
+                end
+            end
+
+            it "creates ruby shims in a dedicated prefixdir" do
+                ws.config.isolate_ruby_shims = true
+                ws.config.save
+                ws.setup
+                %w[gem irb ruby].each do |shim|
+                    assert_equal File.join(ws.prefix_dir, "autoproj", "bin", shim), ws.which(shim)
+                end
+            end
         end
 
         describe "update_autoproj" do


### PR DESCRIPTION
CMake automatically adds the parent folder of each path in `PATH` to its search paths, (partially) defeating the purpose of the setting.