### PR TITLE
fix: make sure 'bundle install' is always called during updates

### DIFF
--- a/lib/autoproj/cli/update.rb
+++ b/lib/autoproj/cli/update.rb
@@ -130,8 +130,8 @@ module Autoproj
                 ws.finalize_setup
                 ws.export_installation_manifest
 
-                if options[:osdeps] && !osdep_packages.empty?
-                    ws.install_os_repositories
+                if options[:osdeps]
+                    ws.install_os_repositories unless osdep_packages.empty?
                     ws.install_os_packages(osdep_packages, **osdeps_options)
                 end
 

--- a/lib/autoproj/os_package_installer.rb
+++ b/lib/autoproj/os_package_installer.rb
@@ -423,7 +423,7 @@ So, what do you want ? (all, none or a comma-separated list of: os gem pip)
         # Requests the installation of the given set of packages
         def install(
             osdep_packages, all: nil, install_only: false,
-            run_package_managers_without_packages: false, **options
+            run_package_managers_without_packages: true, **options
         )
             setup_package_managers(**options)
             partitioned_packages =

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -34,7 +34,7 @@ module Autoproj
 
             # (see Manager#call_while_empty?)
             def call_while_empty?
-                !workspace_configuration_gemfiles.empty?
+                true
             end
 
             # (see Manager#strict?)
@@ -566,13 +566,13 @@ module Autoproj
                            File.read(gemfile_path) != gemfile_contents)
                 if updated
                     Ops.atomic_write(gemfile_path) do |io|
-                        io.puts gemfile_contents
+                        io.write gemfile_contents
                     end
                 end
 
                 options = []
                 binstubs_path = File.join(root_dir, "bin")
-                if updated || !install_only || !File.file?("#{gemfile_path}.lock")
+                if updated || !File.file?("#{gemfile_path}.lock")
                     self.class.run_bundler_install(ws, gemfile_path, *options,
                                                    binstubs: binstubs_path)
                 end


### PR DESCRIPTION
To ensure that a lock file always exists and is up-to-date in the prefix, `BundlerManager#install` must be called during all update operations.

Fixes #419