### PR TITLE
fix: drop --path and similar from bundler invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pkg/
 /.yardoc/
 test/gem_home
 tmp/
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -245,11 +245,8 @@ work with it on an existing workspace.
 Run
 
 ~~~
-bundle install --path=vendor
+bundle install
 ~~~
-
-Note that Autoproj's own test suite assumes that Bundler is setup with
-`--path=vendor`. Keep it that way
 
 To run the test suite,
 

--- a/bin/autoproj_bootstrap
+++ b/bin/autoproj_bootstrap
@@ -464,11 +464,14 @@ module Autoproj
                 # Force bundler to update. If the user does not want this, let
                 # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, "Gemfile.lock")
+                shims_path = File.join(dot_autoproj, "bin")
                 FileUtils.rm lockfile if File.exist?(lockfile)
 
                 run_bundler(bundler, "config", "set", "--local", "path", gems_install_path,
                             bundler_version: bundler_version)
                 run_bundler(bundler, "config", "set", "--local", "shebang", Gem.ruby,
+                            bundler_version: bundler_version)
+                run_bundler(bundler, "config", "set", "--local", "bin", shims_path,
                             bundler_version: bundler_version)
 
                 install_args = ["--gemfile=#{autoproj_gemfile_path}"]
@@ -476,8 +479,7 @@ module Autoproj
                 run_bundler(bundler, "install", *install_args,
                             bundler_version: bundler_version)
 
-                shims_path = File.join(dot_autoproj, "bin")
-                run_bundler(bundler, "binstubs", "--all", "--force", "--path", shims_path,
+                run_bundler(bundler, "binstubs", "--all", "--force",
                             bundler_version: bundler_version)
 
                 bundle_shim_path = File.join(shims_path, "bundle")

--- a/bin/autoproj_install
+++ b/bin/autoproj_install
@@ -464,11 +464,14 @@ module Autoproj
                 # Force bundler to update. If the user does not want this, let
                 # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, "Gemfile.lock")
+                shims_path = File.join(dot_autoproj, "bin")
                 FileUtils.rm lockfile if File.exist?(lockfile)
 
                 run_bundler(bundler, "config", "set", "--local", "path", gems_install_path,
                             bundler_version: bundler_version)
                 run_bundler(bundler, "config", "set", "--local", "shebang", Gem.ruby,
+                            bundler_version: bundler_version)
+                run_bundler(bundler, "config", "set", "--local", "bin", shims_path,
                             bundler_version: bundler_version)
 
                 install_args = ["--gemfile=#{autoproj_gemfile_path}"]
@@ -476,8 +479,7 @@ module Autoproj
                 run_bundler(bundler, "install", *install_args,
                             bundler_version: bundler_version)
 
-                shims_path = File.join(dot_autoproj, "bin")
-                run_bundler(bundler, "binstubs", "--all", "--force", "--path", shims_path,
+                run_bundler(bundler, "binstubs", "--all", "--force",
                             bundler_version: bundler_version)
 
                 bundle_shim_path = File.join(shims_path, "bundle")

--- a/lib/autoproj/ops/install.rb
+++ b/lib/autoproj/ops/install.rb
@@ -454,11 +454,14 @@ module Autoproj
                 # Force bundler to update. If the user does not want this, let
                 # him specify a Gemfile with tighter version constraints
                 lockfile = File.join(dot_autoproj, "Gemfile.lock")
+                shims_path = File.join(dot_autoproj, "bin")
                 FileUtils.rm lockfile if File.exist?(lockfile)
 
                 run_bundler(bundler, "config", "set", "--local", "path", gems_install_path,
                             bundler_version: bundler_version)
                 run_bundler(bundler, "config", "set", "--local", "shebang", Gem.ruby,
+                            bundler_version: bundler_version)
+                run_bundler(bundler, "config", "set", "--local", "bin", shims_path,
                             bundler_version: bundler_version)
 
                 install_args = ["--gemfile=#{autoproj_gemfile_path}"]
@@ -466,8 +469,7 @@ module Autoproj
                 run_bundler(bundler, "install", *install_args,
                             bundler_version: bundler_version)
 
-                shims_path = File.join(dot_autoproj, "bin")
-                run_bundler(bundler, "binstubs", "--all", "--force", "--path", shims_path,
+                run_bundler(bundler, "binstubs", "--all", "--force",
                             bundler_version: bundler_version)
 
                 bundle_shim_path = File.join(shims_path, "bundle")

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -307,8 +307,10 @@ module Autoproj
                             bundler_version: bundler_version)
                 run_bundler(ws, "config", "set", "--local", "shebang", Gem.ruby,
                             bundler_version: bundler_version)
-
-                options << "--binstubs" << binstubs if binstubs
+                if binstubs
+                    run_bundler(ws, "config", "set", "--local", "bin", binstubs,
+                                bundler_version: bundler_version)
+                end
 
                 apply_build_config(ws)
 
@@ -326,6 +328,12 @@ module Autoproj
                             connections << host
                         end
                     end
+                end
+
+                if binstubs
+                    run_bundler(ws, "binstubs", "--all",
+                                bundler_version: bundler_version,
+                                gem_home: gem_home, gemfile: gemfile)
                 end
             end
 

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -303,8 +303,11 @@ module Autoproj
             )
                 FileUtils.rm "#{gemfile}.lock" if update && File.file?("#{gemfile}.lock")
 
-                options << "--path" << gem_path
-                options << "--shebang" << Gem.ruby
+                run_bundler(ws, "config", "set", "--local", "path", gem_path,
+                            bundler_version: bundler_version)
+                run_bundler(ws, "config", "set", "--local", "shebang", Gem.ruby,
+                            bundler_version: bundler_version)
+
                 options << "--binstubs" << binstubs if binstubs
 
                 apply_build_config(ws)

--- a/test/cli/test_watch.rb
+++ b/test/cli/test_watch.rb
@@ -60,12 +60,12 @@ module Autoproj
                     @pkg_set_manifest_file = File.join(pkg_set_manifest_dir,
                                                        "tools", "package.xml")
 
-                    FileUtils.touch(manifest_file)
-                    FileUtils.touch(ros_manifest_file)
+                    File.write(manifest_file, "<package />")
+                    File.write(ros_manifest_file, "<package />")
                     FileUtils.touch(autobuild_file)
                     FileUtils.touch(ruby_file)
                     FileUtils.mkdir_p(File.join(pkg_set_manifest_dir, "tools"))
-                    FileUtils.touch(pkg_set_manifest_file)
+                    File.write(pkg_set_manifest_file, "<package />")
                     sleep 0.1
                     cli.update_workspace
                     cli.setup_notifier

--- a/test/cli/test_watch.rb
+++ b/test/cli/test_watch.rb
@@ -72,7 +72,7 @@ module Autoproj
                     cli.start_watchers
                 end
                 after do
-                    cli.cleanup_notifier
+                    cli.cleanup_notifier if cli.notifier
                 end
 
                 def process_events


### PR DESCRIPTION
Of note here is the different meaning of --path between bundle install and bundle binstubs, where the former uses the configuration entry "path", while the later uses "bin", which they are saying in their documentation but are not clear that those refer to the configuration variables.