### PR TITLE
feat: update the key management scheme to be compatible with recent Debian key management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,18 @@ gem "rubygems-server" unless RUBY_VERSION < "3"
 group :dev do
     gem "rubocop", "~> 1.28.0"
     gem "rubocop-rock"
+
+    if RUBY_VERSION > "3.0"
+        gem "aruba", "~> 2.3.0"
+    else
+        gem "aruba", "~> 2.1.0"
+    end
+
+    gem "flexmock"
+    gem "minitest", ">= 5.0"
+    gem "simplecov"
+    gem "timecop"
+    gem "tty-cursor"
 end
 
 group :vscode do

--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -38,10 +38,4 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "tty-spinner", "~> 0.9.0"
     s.add_runtime_dependency "utilrb", "~> 3.0", ">= 3.0"
     s.add_runtime_dependency "xdg", "= 2.2.5"
-    s.add_development_dependency "aruba", "~> 2.1.0"
-    s.add_development_dependency "flexmock"
-    s.add_development_dependency "minitest", "~> 5.0", ">= 5.0"
-    s.add_development_dependency "simplecov"
-    s.add_development_dependency "timecop"
-    s.add_development_dependency "tty-cursor"
 end

--- a/lib/autoproj/package_managers/bundler_manager.rb
+++ b/lib/autoproj/package_managers/bundler_manager.rb
@@ -401,7 +401,7 @@ module Autoproj
                                               .gsub(/#  from.*/, "")
                             raise ConfigError, cleaned_message
                         end
-                    gems_remotes |= bundler_def.send(:sources).rubygems_remotes.to_set
+                    gems_remotes |= bundler_def.send(:sources).rubygems_sources.flat_map(&:remotes).to_set
                     bundler_def.dependencies.each do |d|
                         d.groups.each do |group_name|
                             if d.platforms.empty?

--- a/lib/autoproj/repository_managers/apt.rb
+++ b/lib/autoproj/repository_managers/apt.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require "open3"
 require "pathname"
@@ -13,15 +13,20 @@ module Autoproj
             attr_reader :sources_dir
             attr_reader :autoproj_sources
 
-            SOURCES_DIR = "/etc/apt".freeze
-            SOURCE_TYPES = %w[deb deb-src].freeze
-            AUTOPROJ_SOURCES = "/etc/apt/sources.list.d/autoproj.list".freeze
+            SOURCES_DIR = "/etc/apt"
+            SOURCE_TYPE_VALIDATION = /^(?:deb|deb-src) /.freeze
+            AUTOPROJ_SOURCES = "/etc/apt/sources.list.d/autoproj.list"
 
-            def initialize(ws, sources_dir: SOURCES_DIR, autoproj_sources: AUTOPROJ_SOURCES)
+            def initialize(
+                ws,
+                sources_dir: SOURCES_DIR, autoproj_sources: AUTOPROJ_SOURCES,
+                root_needed: true
+            )
                 @sources_dir = sources_dir
                 @autoproj_sources = autoproj_sources
                 @source_files = Dir[File.join(sources_dir, "**", "*.list")]
                 @source_entries = {}
+                @root_needed = root_needed
 
                 source_files.each { |file| load_sources_from_file(file) }
                 super(ws)
@@ -42,17 +47,12 @@ module Autoproj
             end
 
             def parse_source_line(line, raise_if_invalid: true)
-                entry = {}
-                entry[:valid] = false
-                entry[:enabled] = true
-                entry[:source] = ""
-                entry[:comment] = ""
+                entry = { valid: false }
 
                 line.strip!
-                if line.start_with?("#")
-                    entry[:enabled] = false
-                    line = line[1..-1]
-                end
+                entry[:enabled] = !line.start_with?("#")
+
+                line = line[1..-1].strip unless entry[:enabled]
 
                 i = line.index("#")
                 if i&.positive?
@@ -60,85 +60,152 @@ module Autoproj
                     line = line[0..(i - 1)]
                 end
 
-                entry[:source] = line.strip
-                chunks = entry[:source].split
-                entry[:valid] = true if SOURCE_TYPES.include?(chunks[0])
-                entry[:source] = chunks.join(" ")
-
+                normalized = line.strip.gsub(/\s+/, " ")
+                entry[:valid] = SOURCE_TYPE_VALIDATION.match?(normalized)
                 if raise_if_invalid && (!entry[:valid] || !entry[:enabled])
                     raise ConfigError, "Invalid source line: #{entry[:source]}"
+                end
+
+                entry[:source] = normalized
+                if (m = /\[signed-by=(.*)\]/.match(line))
+                    entry[:signed_by] = m[1]
+                    entry[:source_id] = "#{m.pre_match.strip} #{m.post_match.strip}"
+                else
+                    entry[:source_id] = entry[:source]
                 end
 
                 entry
             end
 
-            def add_source(source, file = nil)
-                file = if file
-                           File.join(sources_dir, "sources.list.d", file)
-                       else
-                           autoproj_sources
-                       end
+            KeyID = Struct.new :name, :fingerprint
 
-                new_entry = parse_source_line(source)
-                found = entry_exist?(new_entry)
+            def keyid_from_keyfile(path)
+                basename = File.basename(path, File.extname(path))
+                return unless (m = /autoproj_(\w+)_([A-F0-9]+)/.match(basename))
 
-                if found
-                    file = found.first
-                    entry = found.last
-                    return false if entry[:enabled]
-
-                    enable_entry_in_file(file, entry)
-                else
-                    add_entry_to_file(file, new_entry)
-                end
+                KeyID.new(name: m[1], id: m[2])
             end
 
-            def append_entry(contents, entry)
-                unless entry[:enabled]
-                    contents << "#"
-                    contents << " " unless entry[:source].start_with?("#")
+            def add_source(source, file, signed_by: nil)
+                file = File.expand_path(
+                    file, File.join(sources_dir, "sources.list.d")
+                )
+
+                new_entry = parse_source_line(source)
+                entry_update_signed_by(new_entry, signed_by) if signed_by
+                old_file, old_entry = find_matching_entry(new_entry)
+
+                unless old_entry
+                    add_entry_to_file(file, new_entry)
+                    return true
                 end
 
+                needs_update = entry_needs_update?(old_entry, new_entry)
+                return false unless needs_update
+
+                if old_file == file
+                    replace_entry_in_file(file, old_entry, new_entry)
+                    return true
+                elsif !old_entry[:enabled]
+                    # The old entry is disabled, just add
+                    add_entry_to_file(file, new_entry)
+                    return true
+                end
+
+                raise ConfigError,
+                      "entry #{old_entry[:source]} already exists in " \
+                      "#{old_file}, but is different from what autoproj " \
+                      "expects (#{new_entry[:source]}). Update the existing " \
+                      "entry manually, or delete it to let autoproj manage it"
+            end
+
+            def entry_update_signed_by(entry, signed_by)
+                return if entry[:signed_by] == signed_by
+
+                entry[:signed_by] = signed_by
+                source = entry[:source]
+                type, *rest = source.split(" ")
+                rest.shift if rest[0].downcase.start_with?("[signed-by")
+                entry[:source] = [type, "[signed-by=#{signed_by}]", *rest].join(" ")
+            end
+
+            def replace_entry_in_file(file, old_entry, new_entry)
+                entries = source_entries[file]
+                idx = entries.index(old_entry)
+                entries[idx] = new_entry
+            end
+
+            def entry_needs_update?(old, new)
+                old[:enabled] != new[:enabled] ||
+                    old[:signed_by] != new[:signed_by]
+            end
+
+            # @api private
+            #
+            # Generate the content for the given file based on the entries in
+            # source_entries
+            def generate_file(file)
+                contents = []
+                @source_entries[file].each do |entry|
+                    generate_file_append_entry(contents, entry)
+                end
+                contents.join
+            end
+
+            # @api private
+            #
+            # Convert a source entry into a line suitable for a source file
+            def generate_file_append_entry(contents, entry)
+                contents << "# " unless entry[:enabled]
+
                 contents << entry[:source]
-                contents << "# #{entry[:comment]}" unless entry[:comment].empty?
+                contents << " # #{entry[:comment]}" if entry[:comment]
                 contents << "\n"
             end
 
-            def enable_entry_in_file(file, enable_entry)
-                contents = ""
-                source_entries[file].each do |entry|
-                    entry[:enabled] = true if enable_entry[:source] == entry[:source]
-                    append_entry(contents, entry)
-                end
-                run_tee_command(["sudo", "tee", file], contents)
-                true
-            end
-
             def add_entry_to_file(file, entry)
-                run_tee_command(["sudo", "tee", "-a", file], entry[:source])
                 @source_entries[file] ||= []
                 @source_entries[file] << entry
-                true
             end
 
-            def run_tee_command(command, contents)
+            def update_source_file(file)
+                run_tee_command(file, generate_file(file))
+            end
+
+            def run_tee_command(file, contents)
                 contents = StringIO.new("#{contents}\n")
-                Autobuild::Subprocess.run("autoproj", "osrepos", *command, input_streams: [contents])
+                Autobuild::Subprocess.run(
+                    "autoproj", "osrepos", *cmd_acquire_root, "tee", file,
+                    input_streams: [contents]
+                )
             end
 
-            def entry_exist?(new_entry)
+            def cmd_acquire_root
+                return [] unless @root_needed
+
+                ["sudo"]
+            end
+
+            # Find an entry that refers to the same source than the given entry hash
+            #
+            # Note that the returned entry is not exactly the same. It may have a different
+            # signed-by key and/or have an `enabled` flag that is different`
+            #
+            # @return [(String,Hash),nil] the matching file and entry hash
+            def find_matching_entry(new_entry)
                 source_entries.each_pair do |file, entries|
-                    entry = entries.find { |e| e[:source] == new_entry[:source] }
+                    entry = entries.find { |e| e[:source_id] == new_entry[:source_id] }
                     return [file, entry] if entry
                 end
+
                 nil
             end
 
-            def source_exist?(source)
-                entry_exist?(parse_source_line(source))
+            def find_matching_entry_from_repo(repo)
+                find_matching_entry(parse_source_line(repo))
             end
 
-            def key_exist?(key)
+            def anonymous_key_exist?(key)
                 exist = false
                 Open3.popen3({ "LANG" => "C" }, "apt-key", "export", key) do |_, _, stderr, wait_thr|
                     success = wait_thr.value.success?
@@ -153,78 +220,10 @@ module Autoproj
                 Autobuild::Subprocess.run(
                     "autoproj",
                     "osrepos",
-                    "sudo",
+                    *cmd_acquire_root,
                     "apt-get",
                     "update"
                 )
-            end
-
-            def add_apt_key(id, origin, type: :keyserver)
-                if type == :keyserver
-                    Autobuild::Subprocess.run(
-                        "autoproj",
-                        "osrepos",
-                        "sudo",
-                        "apt-key",
-                        "adv",
-                        "--keyserver",
-                        origin,
-                        "--recv-key",
-                        id
-                    )
-                else
-                    URI(origin).open do |io|
-                        Autobuild::Subprocess.run(
-                            "autoproj",
-                            "osrepos",
-                            "sudo",
-                            "apt-key",
-                            "add",
-                            "-",
-                            input_streams: [io]
-                        )
-                    end
-                end
-            rescue Errno::ENOENT, SocketError => e
-                raise ConfigError, e.message
-            end
-
-            def filter_installed_definitions(definitions)
-                definitions = definitions.dup.reject do |definition|
-                    if definition["type"] == "repo"
-                        _, entry = source_exist?(definition["repo"])
-                        entry && entry[:enabled]
-                    else
-                        key_exist?(definition["id"])
-                    end
-                end
-                definitions
-            end
-
-            def print_installing_definitions(definitions)
-                repos = definitions.select { |definition| definition["type"] == "repo" }
-                keys = definitions.select { |definition| definition["type"] == "key" }
-
-                unless repos.empty?
-                    Autoproj.message "  adding apt repositories:"
-                    repos.each do |repo|
-                        if repo["file"]
-                            Autoproj.message "    #{repo['repo']}, file: #{repo['file']}"
-                        else
-                            Autoproj.message "    #{repo['repo']}"
-                        end
-                    end
-                end
-                return if keys.empty?
-
-                Autoproj.message "  adding apt keys:"
-                keys.each do |key|
-                    if key["keyserver"]
-                        Autoproj.message "    id: #{key['id']}, keyserver: #{key['keyserver']}"
-                    else
-                        Autoproj.message "    id: #{key['id']}, url: #{key['url']}"
-                    end
-                end
             end
 
             # Validates repositories definitions from .osrepos files
@@ -262,7 +261,7 @@ module Autoproj
                 end
             end
 
-            INVALID_REPO_MESSAGE = "Invalid apt repository definition".freeze
+            INVALID_REPO_MESSAGE = "Invalid apt repository definition"
 
             # rubocop:disable Style/GuardClause
 
@@ -306,20 +305,137 @@ module Autoproj
 
             def install(definitions)
                 super
-                validate_definitions(definitions)
-                definitions = filter_installed_definitions(definitions)
-                print_installing_definitions(definitions)
 
-                definitions.each do |definition|
-                    if definition["type"] == "repo"
-                        add_source(definition["repo"], definition["file"])
+                validate_definitions(definitions)
+
+                keys, repos = definitions.partition { _1["type"] == "key" }
+                named_keys = keys.to_h { [_1["name"], _1] }
+
+                updated_files = install_repos(repos, named_keys)
+                install_keys(keys)
+                updated_files.each do |path|
+                    update_source_file(path)
+                end
+                apt_update unless updated_files.empty?
+            end
+
+            def install_repos(repos, named_keys)
+                repos.each_with_object(Set.new) do |definition, updated_files|
+                    repo = definition["repo"]
+                    file = definition["file"] || autoproj_sources
+                    if (key_name = definition["key"])
+                        unless (keydef = named_keys[key_name])
+                            raise ConfigError,
+                                  "key '#{key_name}' is referenced by entry " \
+                                  "#{definition['repo']} from #{file}}, " \
+                                  "but this key is not defined"
+                        end
+
+                        signed_by = signed_by_path_from_named_key(keydef)
+                    end
+
+                    next unless add_source(repo, file, signed_by: signed_by)
+
+                    Autoproj.message "  added or updated apt repository"
+                    if definition["file"]
+                        Autoproj.message "    #{repo}, file: #{filec}"
                     else
-                        type = definition["url"] ? "url" : "keyserver"
-                        origin = definition[type]
-                        add_apt_key(definition["id"], origin, type: type.to_sym)
+                        Autoproj.message "    #{repo}"
+                    end
+                    updated_files << file
+                end
+            end
+
+            def install_keys(keys)
+                keys.each do |keydef|
+                    if keydef["name"]
+                        install_named_key(keydef)
+                    else
+                        install_anonymous_key(keydef)
                     end
                 end
-                apt_update unless definitions.empty?
+            end
+
+            def signed_by_path_from_named_key(keydef)
+                name = keydef.fetch("name")
+                id = keydef.fetch("id")
+                ext =
+                    if keydef["url"]
+                        # Assuming ascii-armored file
+                        ".asc"
+                    else
+                        ".gpg"
+                    end
+
+                File.join(@sources_dir, "keyrings", "autoproj_#{name}_#{id}#{ext}")
+            end
+
+            def install_named_key(keydef)
+                path = signed_by_path_from_named_key(keydef)
+                return if File.exist?(path)
+
+                Autoproj.message "  adding apt key"
+
+                key_id = keydef.fetch("id")
+                if (url = keydef["url"])
+                    Autoproj.message "    id: #{key_id}, url: #{url}"
+                    add_named_key_from_url(path, url)
+                else
+                    keyserver = keydef.fetch("keyserver")
+                    Autoproj.message "    id: #{key_id}, keyserver: #{keyserver}"
+                    add_named_key_from_keyserver(path, key_id, keyserver)
+                end
+            end
+
+            def install_anonymous_key(definition)
+                key_id = definition["id"]
+                return if anonymous_key_exist?(key_id)
+
+                Autoproj.message "  adding apt key"
+
+                if (url = definition["url"])
+                    Autoproj.message "    id: #{key_id}, url: #{url}"
+                    add_anonymous_key_from_url(url)
+                else
+                    keyserver = definition.fetch("keyserver")
+                    Autoproj.message "    id: #{key_id}, keyserver: #{keyserver}"
+                    add_anonymous_key_from_keyserver(key_id, keyserver)
+                end
+            end
+
+            def add_named_key_from_keyserver(path, id, keyserver)
+                Autobuild::Subprocess.run(
+                    "autoproj", "osrepos",
+                    *cmd_acquire_root, "gpg",
+                    "--no-default-keyring",
+                    "--keyserver", keyserver, "--keyring", path, "--recv-keys", id
+                )
+            end
+
+            def add_named_key_from_url(path, url)
+                run_tee_command(path, URI(url).read)
+            rescue Errno::ENOENT, SocketError => e
+                raise ConfigError, e.message
+            end
+
+            def add_anonymous_key_from_keyserver(id, keyserver)
+                Autobuild::Subprocess.run(
+                    "autoproj", "osrepos",
+                    *cmd_acquire_root, "apt-key", "adv",
+                    "--keyserver", keyserver, "--recv-key", id
+                )
+            end
+
+            def add_anonymous_key_from_url(url)
+                URI(url).open do |io|
+                    Autobuild::Subprocess.run(
+                        "autoproj", "osrepos",
+                        *cmd_acquire_root, "apt-key", "add", "-",
+                        input_streams: [io]
+                    )
+                end
+            rescue Errno::ENOENT, SocketError => e
+                raise ConfigError, e.message
             end
         end
     end

--- a/test/repository_managers/test_apt.rb
+++ b/test/repository_managers/test_apt.rb
@@ -14,36 +14,22 @@ module Autoproj
                 @ws = ws_create
                 @sources_dir = ws.root_dir
                 @autoproj_sources = File.join(sources_dir, "autoproj.list")
-                @sources_file = File.join(File.dirname(__FILE__), "sources.list.d", "sources.list")
+                @sources_file = File.join(
+                    File.dirname(__FILE__), "sources.list.d", "sources.list"
+                )
 
-                FileUtils.cp(sources_file, sources_dir)
+                FileUtils.cp(sources_file, autoproj_sources)
                 @subject = Autoproj::RepositoryManagers::APT.new(
                     ws,
                     sources_dir: sources_dir,
-                    autoproj_sources: autoproj_sources
+                    autoproj_sources: autoproj_sources,
+                    root_needed: false
                 )
             end
 
             it "loads existing entries" do
-                entries = {
-                    File.join(sources_dir, "sources.list") => [
-                        {
-                            valid: true,
-                            enabled: true,
-                            source: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted",
-                            comment: ""
-                        },
-                        {
-                            valid: true,
-                            enabled: false,
-                            source: "deb http://archive.canonical.com/ubuntu xenial partner",
-                            comment: ""
-                        }
-                    ]
-                }
-
-                assert_equal subject.source_files, [File.join(sources_dir, "sources.list")]
-                assert_equal subject.source_entries, entries
+                assert_equal subject.source_files, [File.join(sources_dir, "autoproj.list")]
+                assert_equal fixture_source_list_entries, subject.source_entries
             end
 
             describe "#parse_source_line" do
@@ -53,54 +39,83 @@ module Autoproj
                     end
                 end
             end
+
             describe "#add_source" do
-                it "uncomment line if entry exists" do
+                it "enables an entry if it already exists" do
                     line = "deb http://archive.canonical.com/ubuntu xenial partner"
-                    updated_file = <<~EOFSOURCE
-                        deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted
-                        deb http://archive.canonical.com/ubuntu xenial partner\n
-                    EOFSOURCE
+                    assert subject.add_source(line, autoproj_sources)
 
-                    flexmock(Autobuild::Subprocess)
-                        .should_receive(:run)
-                        .with(
-                            "autoproj",
-                            "osrepos",
-                            "sudo",
-                            "tee",
-                            File.join(sources_dir, "sources.list")
-                        )
-                        .with_kw_args(
-                            input_streams: on { |ios| ios.first.read == updated_file }
-                        )
-
-                    assert subject.add_source(line)
+                    entries = fixture_source_list_entries
+                    entries[autoproj_sources][1][:enabled] = true
+                    assert_equal entries, subject.source_entries
                 end
+
                 it "append line to file if entry does not exist" do
                     line = "deb http://packages.ros.org/ros/ubuntu xenial main"
-                    flexmock(Autobuild::Subprocess)
-                        .should_receive(:run)
-                        .with(
-                            "autoproj",
-                            "osrepos",
-                            "sudo",
-                            "tee",
-                            "-a",
-                            autoproj_sources
-                        ).with_kw_args(
-                            input_streams: on { |ios| ios.first.read == "#{line}\n" }
-                        )
+                    assert subject.add_source(line, autoproj_sources)
 
-                    assert subject.add_source(line)
+                    entries = fixture_source_list_entries
+                    entries[autoproj_sources] << {
+                        valid: true,
+                        enabled: true,
+                        source: "deb http://packages.ros.org/ros/ubuntu xenial main",
+                        source_id: "deb http://packages.ros.org/ros/ubuntu xenial main"
+                    }
+                    assert_equal entries, subject.source_entries
                 end
+
                 it "does nothing if entry exists and is enabled" do
                     line = "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
-                    flexmock(Autobuild::Subprocess)
-                        .should_receive(:run)
-                        .with(any)
-                        .never
+                    refute subject.add_source(line, autoproj_sources)
+                    assert_equal fixture_source_list_entries, subject.source_entries
+                end
 
-                    refute subject.add_source(line)
+                it "detects a new signed-by key" do
+                    line = "deb [signed-by=/some/path] http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    assert subject.add_source(line, autoproj_sources)
+
+                    entries = fixture_source_list_entries
+                    entries[autoproj_sources][0] = {
+                        valid: true,
+                        enabled: true,
+                        signed_by: "/some/path",
+                        source: "deb [signed-by=/some/path] http://br.archive.ubuntu.com/ubuntu/ xenial main restricted",
+                        source_id: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    }
+                    assert_equal entries, subject.source_entries
+                end
+
+                it "allows adding a new signed-by path by argument" do
+                    line = "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    assert subject.add_source(line, autoproj_sources, signed_by: "/some/path")
+
+                    entries = fixture_source_list_entries
+                    entries[autoproj_sources][0] = {
+                        valid: true,
+                        enabled: true,
+                        signed_by: "/some/path",
+                        source: "deb [signed-by=/some/path] http://br.archive.ubuntu.com/ubuntu/ xenial main restricted",
+                        source_id: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    }
+                    assert_equal entries, subject.source_entries
+                end
+
+                it "allows changing a signed-by path by argument" do
+                    line = "deb [signed-by=/some/path] http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    assert subject.add_source(line, autoproj_sources)
+
+                    line = "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    assert subject.add_source(line, autoproj_sources, signed_by: "/some/other/path")
+
+                    entries = fixture_source_list_entries
+                    entries[autoproj_sources][0] = {
+                        valid: true,
+                        enabled: true,
+                        signed_by: "/some/other/path",
+                        source: "deb [signed-by=/some/other/path] http://br.archive.ubuntu.com/ubuntu/ xenial main restricted",
+                        source_id: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                    }
+                    assert_equal entries, subject.source_entries
                 end
             end
             describe "#install" do
@@ -120,17 +135,16 @@ module Autoproj
                     @subject = flexmock(subject)
 
                     subject
-                        .should_receive(:source_exist?)
+                        .should_receive(:find_matching_entry_from_repo)
                         .with(repo)
                         .and_return([sources_file, enabled: true])
 
                     subject
-                        .should_receive(:key_exist?)
+                        .should_receive(:anonymous_key_exist?)
                         .with("ABC")
                         .and_return(true)
 
-                    subject.should_receive(:add_source).with(any, any).never
-                    subject.should_receive(:add_apt_key).with(any, any, any).never
+                    subject.should_receive(:add_anonymous_key_from_keyserver).never
                     subject.should_receive(:apt_update).never
                     subject.install(definitions)
                 end
@@ -154,21 +168,93 @@ module Autoproj
                     ]
                     @subject = flexmock(subject)
 
-                    subject.should_receive(:add_source).with(repo, nil).once.ordered
-                    subject.should_receive(:add_apt_key).with(
+                    subject.should_receive(:add_anonymous_key_from_keyserver).with(
                         "ABC",
-                        "hkp://foo",
-                        type: :keyserver
+                        "hkp://foo"
                     ).once.ordered
-                    subject.should_receive(:add_apt_key).with(
-                        "DEF",
-                        "http://foo/bar.key",
-                        type: :url
+                    subject.should_receive(:add_anonymous_key_from_url).with(
+                        "http://foo/bar.key"
                     ).once.ordered
 
                     subject.should_receive(:apt_update).once.ordered
                     subject.install(definitions)
+
+                    expected = <<~CONTENT
+                        deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted
+                        # deb http://archive.canonical.com/ubuntu xenial partner
+                        deb http://packages.ros.org/ros/ubuntu xenial main
+                    CONTENT
+                    assert_equal expected.strip, File.read(autoproj_sources).strip
                 end
+                it "uses the new key management scheme for named keys" do
+                    repo = "deb http://packages.ros.org/ros/ubuntu xenial main"
+                    repo2 = "deb http://packages.ros.org/ros/ubuntu2 xenial main"
+                    definitions = [
+                        {
+                            "type" => "repo",
+                            "repo" => repo,
+                            "key" => "test"
+                        },
+                        {
+                            "type" => "key",
+                            "name" => "test",
+                            "id" => "ABC",
+                            "keyserver" => "hkp://foo"
+                        },
+                        {
+                            "type" => "repo",
+                            "repo" => repo2,
+                            "key" => "test2"
+                        },
+                        {
+                            "type" => "key",
+                            "name" => "test2",
+                            "id" => "DEF",
+                            "url" => "https://somewhere/somefile.key"
+                        }
+                    ]
+                    @subject = flexmock(subject)
+
+                    subject.should_receive(:add_named_key_from_keyserver).with(
+                        "#{sources_dir}/keyrings/autoproj_test_ABC.gpg",
+                        "ABC",
+                        "hkp://foo"
+                    ).once.ordered
+                    subject.should_receive(:add_named_key_from_url).with(
+                        "#{sources_dir}/keyrings/autoproj_test2_DEF.asc",
+                        "https://somewhere/somefile.key"
+                    ).once.ordered
+
+                    subject.should_receive(:apt_update).once.ordered
+                    subject.install(definitions)
+
+                    expected = <<~CONTENT
+                        deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted
+                        # deb http://archive.canonical.com/ubuntu xenial partner
+                        deb [signed-by=#{sources_dir}/keyrings/autoproj_test_ABC.gpg] http://packages.ros.org/ros/ubuntu xenial main
+                        deb [signed-by=#{sources_dir}/keyrings/autoproj_test2_DEF.asc] http://packages.ros.org/ros/ubuntu2 xenial main
+                    CONTENT
+                    assert_equal expected.strip, File.read(autoproj_sources).strip
+                end
+            end
+
+            def fixture_source_list_entries
+                {
+                    autoproj_sources => [
+                        {
+                            valid: true,
+                            enabled: true,
+                            source: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted",
+                            source_id: "deb http://br.archive.ubuntu.com/ubuntu/ xenial main restricted"
+                        },
+                        {
+                            valid: true,
+                            enabled: false,
+                            source: "deb http://archive.canonical.com/ubuntu xenial partner",
+                            source_id: "deb http://archive.canonical.com/ubuntu xenial partner"
+                        }
+                    ]
+                }
             end
         end
     end


### PR DESCRIPTION
apt-key is deprecated. One is now supposed to save the keys separately in
/etc/apt/keyrings and refer to them with the signed-by attribute.

This commit updates the existing scheme to allow for named keys, that is
the 'keys' entries in osrepos can have a 'name' entry, and the 'repo' entries
should have a 'key' entry with the name of that key

If a key has a name, it is saved in /etc/apt/keyrings instead of being passed
to apt-key. If a repo has a 'key' entry, it gets the corresponding signed-by
attribute.