### PR TITLE
Allow newer utilrb versions

### DIFF
--- a/autoproj.gemspec
+++ b/autoproj.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "tty-color", "~> 0.5.0"
     s.add_runtime_dependency "tty-prompt", "~> 0.21.0"
     s.add_runtime_dependency "tty-spinner", "~> 0.9.0"
-    s.add_runtime_dependency "utilrb", "~> 3.0.0", ">= 3.0.0"
+    s.add_runtime_dependency "utilrb", "~> 3.0", ">= 3.0"
     s.add_runtime_dependency "xdg", "= 2.2.5"
     s.add_development_dependency "aruba", "~> 2.1.0"
     s.add_development_dependency "flexmock"


### PR DESCRIPTION
The current dependency

    "utilrb", "~> 3.0.0", ">= 3.0.0"

only allows utilrb versions 3.0.x (which is why autoproj still installs version 3.0.1, even though version 3.1.0 exists)

The `">= 3.0"` is actually implied by `"~> 3.0"` and could be removed, if I understand this correctly (similar for other dependencies).